### PR TITLE
Possibility to not handle logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,3 +153,9 @@ docker stack deploy --compose-file docker-compose.yml docker-swarm-dashboard
 ```
 docker service create --name logger chentex/random-logger:latest 50 200
 ```
+
+### Configuration
+
+Docker Swarm Dashboard supports environment variables for configuration
+
+* `DSD_HANDLE_LOGS`: Set to `false` to prevent fetching and displaying logs

--- a/app-src/src/App.js
+++ b/app-src/src/App.js
@@ -16,17 +16,21 @@ import { DashboardNavbar } from './components/DashboardNavbar'
 import LoadingComponent from './components/LoadingComponent'
 import { ErrorBoundary } from './common/ErrorBoundary'
 import bg from './files/docker.png'
+import { useAtomValue } from 'jotai/index'
+import { dashboardSettingsAtom } from './common/store/atoms'
 
 library.add(fab, fas, far)
 
 SyntaxHighlighter.registerLanguage('javascript', js)
 
 const App = () => {
+  const dashboardSettings = useAtomValue(dashboardSettingsAtom)
+
   return (
     <Provider>
       <div className="App">
         <img alt="background" id="background-image" src={bg} />
-        <DashboardNavbar />
+        <DashboardNavbar dashboardSettings={dashboardSettings} />
         <main role="main">
           <Container fluid className="overflow-auto">
             <ErrorBoundary>

--- a/app-src/src/common/store/atoms.js
+++ b/app-src/src/common/store/atoms.js
@@ -128,3 +128,8 @@ export const currentVariantClassesAtom = atom((get) =>
 export const currentSyntaxHighlighterStyleAtom = atom((get) =>
   get(isDarkModeAtom) ? a11yDark : a11yLight,
 )
+
+// Dashboard settings
+export const dashboardSettingsAtom = atom(async (get) => {
+  return (await fetch(get(baseUrlAtom) + 'docker/dashboard-settings')).json()
+})

--- a/app-src/src/components/DashboardNavbar.js
+++ b/app-src/src/components/DashboardNavbar.js
@@ -37,7 +37,7 @@ import {
   tasksId,
 } from '../common/navigationConstants'
 
-function DashboardNavbar() {
+function DashboardNavbar({ dashboardSettings }) {
   const [refreshInterval, toggleRefresh] = useAtom(
     refreshIntervalAtom,
     RefreshIntervalToggleReducer,
@@ -142,14 +142,16 @@ function DashboardNavbar() {
               >
                 <FontAwesomeIcon icon="building" /> Ports
               </Nav.Link>
-              <Nav.Link
-                onClick={() => updateView({ id: logsId })}
-                active={view?.id === logsId}
-                className="warning"
-              >
-                <FontAwesomeIcon icon="file-medical-alt" /> Logs
-                {readingLogsWarning}
-              </Nav.Link>
+              {dashboardSettings.showLogsButton && (
+                <Nav.Link
+                  onClick={() => updateView({ id: logsId })}
+                  active={view?.id === logsId}
+                  className="warning"
+                >
+                  <FontAwesomeIcon icon="file-medical-alt" /> Logs
+                  {readingLogsWarning}
+                </Nav.Link>
+              )}
             </Nav>
           </Navbar.Collapse>
           <Navbar.Collapse

--- a/server-src/dashboardsettingshandler.go
+++ b/server-src/dashboardsettingshandler.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type dashboardSettings struct {
+	ShowLogsButton bool `json:"showLogsButton"`
+}
+
+func dashboardSettingsHandler(w http.ResponseWriter, _ *http.Request) {
+	jsonString, _ := json.Marshal(dashboardSettings{handlingLogs})
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(jsonString)
+}

--- a/server-src/dockerswarmdashboard.go
+++ b/server-src/dockerswarmdashboard.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 
 	"github.com/docker/docker/client"
 	"github.com/gorilla/handlers"
@@ -12,6 +13,14 @@ import (
 
 func main() {
 	log.Println("Starting Docker Swarm Dashboard...")
+
+	handleLogsEnvValue, handleLogsSet := os.LookupEnv("DSD_HANDLE_LOGS")
+	handleLogs := true
+	if handleLogsSet {
+		handleLogs, _ = strconv.ParseBool(handleLogsEnvValue)
+		log.Println("Handle logs:", handleLogs)
+	}
+
 	router := mux.NewRouter().StrictSlash(true)
 
 	// CORS Headers
@@ -26,7 +35,9 @@ func main() {
 	router.HandleFunc("/docker/nodes/{id}", dockerNodesDetailsHandler)
 	router.HandleFunc("/docker/tasks", dockerTasksHandler)
 	router.HandleFunc("/docker/tasks/{id}", dockerTasksDetailsHandler)
-	router.HandleFunc("/docker/logs/{id}", dockerServiceLogsHandler)
+	if handleLogs {
+		router.HandleFunc("/docker/logs/{id}", dockerServiceLogsHandler)
+	}
 	router.HandleFunc("/ui/dashboardh", dashboardHHandler)
 	router.HandleFunc("/ui/dashboardv", dashboardVHandler)
 	router.HandleFunc("/ui/timeline", timelineHandler)

--- a/server-src/dockerswarmdashboard.go
+++ b/server-src/dockerswarmdashboard.go
@@ -11,14 +11,16 @@ import (
 	"github.com/gorilla/mux"
 )
 
+var (
+	handlingLogs = true
+)
+
 func main() {
 	log.Println("Starting Docker Swarm Dashboard...")
 
 	handleLogsEnvValue, handleLogsSet := os.LookupEnv("DSD_HANDLE_LOGS")
-	handleLogs := true
 	if handleLogsSet {
-		handleLogs, _ = strconv.ParseBool(handleLogsEnvValue)
-		log.Println("Handle logs:", handleLogs)
+		handlingLogs, _ = strconv.ParseBool(handleLogsEnvValue)
 	}
 
 	router := mux.NewRouter().StrictSlash(true)
@@ -35,9 +37,10 @@ func main() {
 	router.HandleFunc("/docker/nodes/{id}", dockerNodesDetailsHandler)
 	router.HandleFunc("/docker/tasks", dockerTasksHandler)
 	router.HandleFunc("/docker/tasks/{id}", dockerTasksDetailsHandler)
-	if handleLogs {
+	if handlingLogs {
 		router.HandleFunc("/docker/logs/{id}", dockerServiceLogsHandler)
 	}
+	router.HandleFunc("/docker/dashboard-settings", dashboardSettingsHandler)
 	router.HandleFunc("/ui/dashboardh", dashboardHHandler)
 	router.HandleFunc("/ui/dashboardv", dashboardVHandler)
 	router.HandleFunc("/ui/timeline", timelineHandler)


### PR DESCRIPTION
[SPK](https://www.spk.no/en/) has been using an old fork of Docker Swarm Dashboard. We decided we want to upgrade to a newer version, but due to privacy concerns we can't display the logs.

I've added the possibility of disabling the log-handling in the backend using an environment variable and added a new endpoint which is used to configure the static frontend to not render the Logs-button.

If these changes looks OK I'd like to add more configuration settings like default to column view instead of row-view and hide failed/rejected/shutdown pills in the overview.