### PR TITLE
fix: show absolute metrics when no limits/quota configured

### DIFF
--- a/app-src/src/components/services/ServiceMetricsComponent.jsx
+++ b/app-src/src/components/services/ServiceMetricsComponent.jsx
@@ -161,6 +161,7 @@ const ServiceMetricsComponent = React.memo(function ServiceMetricsComponent({
   // Total Memory Usage Chart (Donut)
   const totalMemUsed = totalUsage
   const totalMemAvailable = totalLimit > 0 ? totalLimit - totalUsage : 0
+  const hasTotalLimit = totalLimit > 0
 
   const totalMemoryChartOptions = {
     ...commonOpts,
@@ -169,7 +170,7 @@ const ServiceMetricsComponent = React.memo(function ServiceMetricsComponent({
       type: 'donut',
       height: 350,
     },
-    labels: ['Used', 'Available'],
+    labels: hasTotalLimit ? ['Used', 'Available'] : ['Used'],
     plotOptions: {
       pie: {
         donut: {
@@ -177,9 +178,11 @@ const ServiceMetricsComponent = React.memo(function ServiceMetricsComponent({
             show: true,
             total: {
               show: true,
-              label: 'Total Limit',
+              label: hasTotalLimit ? 'Total Limit' : 'Total Used',
               formatter: () =>
-                totalLimit > 0 ? formatBytes(totalLimit) : NO_LIMIT_TEXT,
+                hasTotalLimit
+                  ? formatBytes(totalLimit)
+                  : formatBytes(totalMemUsed),
             },
           },
         },
@@ -192,8 +195,10 @@ const ServiceMetricsComponent = React.memo(function ServiceMetricsComponent({
     colors: CHART_PALETTES.memory,
   }
 
-  const totalMemoryChartSeries =
-    totalLimit > 0 ? [totalMemUsed, totalMemAvailable] : [totalMemUsed, 0]
+  // Without limit, only show the used slice
+  const totalMemoryChartSeries = hasTotalLimit
+    ? [totalMemUsed, totalMemAvailable]
+    : [totalMemUsed]
 
   // Container Memory Usage Bar Chart
   const containerMemoryChartOptions = {

--- a/app-src/src/components/tasks/details/CpuCharts.jsx
+++ b/app-src/src/components/tasks/details/CpuCharts.jsx
@@ -12,6 +12,8 @@ import {
  * @returns {{ cpuGaugeOptions, cpuGaugeSeries, cpuBreakdownOptions, cpuBreakdownSeries }}
  */
 export function buildCPUCharts(m, commonOpts) {
+  const hasQuota = m.cpuPercent > 0
+
   const cpuGaugeOptions = {
     ...commonOpts,
     chart: { ...commonOpts.chart, type: 'radialBar' },
@@ -24,17 +26,24 @@ export function buildCPUCharts(m, commonOpts) {
           name: { fontSize: GAUGE_DEFAULTS.nameFontSize, offsetY: -10 },
           value: {
             fontSize: GAUGE_DEFAULTS.valueFontSize,
-            formatter: (val) => `${parseFloat(val).toFixed(1)}%`,
+            formatter: (val) => {
+              if (hasQuota) {
+                return `${parseFloat(val).toFixed(1)}%`
+              }
+              // Without quota, show absolute CPU time
+              return `${(m.cpuUsage || 0).toFixed(2)}s`
+            },
           },
         },
         track: { background: getGaugeTrackBackground() },
       },
     },
-    colors: [getStatusColor(m.cpuPercent)],
-    labels: ['CPU Quota'],
+    colors: [hasQuota ? getStatusColor(m.cpuPercent) : CHART_PALETTES.cpu[0]],
+    labels: [hasQuota ? 'CPU Quota' : 'CPU Time'],
   }
+  // Without quota, show empty gauge
   const cpuGaugeSeries = [
-    Math.min(parseFloat((m.cpuPercent || 0).toFixed(1)), 100),
+    hasQuota ? Math.min(parseFloat((m.cpuPercent || 0).toFixed(1)), 100) : 0,
   ]
 
   const userSec = m.cpuUserSeconds || 0

--- a/app-src/src/components/tasks/details/MemoryCharts.jsx
+++ b/app-src/src/components/tasks/details/MemoryCharts.jsx
@@ -73,6 +73,9 @@ export function createMemoryDonutOptions(m, commonOpts, formatBytes) {
  * @returns {{ memGaugeOptions, memGaugeSeries, memDonutOptions, memDonutSeries }}
  */
 export function buildMemoryCharts(m, commonOpts) {
+  const hasLimit = m.limit > 0
+
+  // Gauge: shows percentage if limit exists, otherwise shows absolute usage
   const memGaugeOptions = {
     ...commonOpts,
     chart: { ...commonOpts.chart, type: 'radialBar' },
@@ -85,16 +88,27 @@ export function buildMemoryCharts(m, commonOpts) {
           name: { fontSize: GAUGE_DEFAULTS.nameFontSize, offsetY: -10 },
           value: {
             fontSize: GAUGE_DEFAULTS.valueFontSize,
-            formatter: (val) => `${parseFloat(val).toFixed(1)}%`,
+            formatter: (val) => {
+              if (hasLimit) {
+                return `${parseFloat(val).toFixed(1)}%`
+              }
+              // Without limit, show absolute value
+              return formatBytes(m.usage || 0)
+            },
           },
         },
         track: { background: getGaugeTrackBackground() },
       },
     },
-    colors: [getStatusColor(m.usagePercent)],
+    colors: [
+      hasLimit ? getStatusColor(m.usagePercent) : CHART_PALETTES.memory[0],
+    ],
     labels: ['Memory'],
   }
-  const memGaugeSeries = [parseFloat((m.usagePercent || 0).toFixed(1))]
+  // Without limit, show empty gauge or minimal fill
+  const memGaugeSeries = [
+    hasLimit ? parseFloat((m.usagePercent || 0).toFixed(1)) : 0,
+  ]
 
   const { memCache, workingSet, otherUsed, memAvailable } =
     calculateMemoryMetrics(m)

--- a/app-src/src/components/tasks/details/TaskMetricsContent.jsx
+++ b/app-src/src/components/tasks/details/TaskMetricsContent.jsx
@@ -180,7 +180,7 @@ const TaskMetricsContent = React.memo(function TaskMetricsContent({
 
           <MetricGrid>
             <MetricCard title="Memory Usage" icon="memory" chartContent>
-              {taskMetrics.limit > 0 || taskMetrics.usagePercent > 0 ? (
+              {taskMetrics.usage > 0 || taskMetrics.workingSet > 0 ? (
                 <Row>
                   <Col xs={12} md={5} className="mb-3 mb-md-0">
                     <ReactApexChart
@@ -201,13 +201,15 @@ const TaskMetricsContent = React.memo(function TaskMetricsContent({
                 </Row>
               ) : (
                 <Alert variant="info" className="mb-0">
-                  No memory limit configured
+                  No memory data available
                 </Alert>
               )}
             </MetricCard>
 
             <MetricCard title="CPU Usage" icon="microchip" chartContent>
-              {taskMetrics.cpuPercent > 0 ? (
+              {taskMetrics.cpuUsage > 0 ||
+              taskMetrics.cpuUserSeconds > 0 ||
+              taskMetrics.cpuSystemSeconds > 0 ? (
                 <Row>
                   <Col
                     xs={12}
@@ -234,7 +236,7 @@ const TaskMetricsContent = React.memo(function TaskMetricsContent({
                 </Row>
               ) : (
                 <Alert variant="info" className="mb-0">
-                  CPU details not available (no quota configured)
+                  No CPU data available
                 </Alert>
               )}
             </MetricCard>

--- a/app-src/tests/unit/components/tasks/details/TaskMetricsContent.test.js
+++ b/app-src/tests/unit/components/tasks/details/TaskMetricsContent.test.js
@@ -196,7 +196,29 @@ describe('TaskMetricsContent', () => {
       expect(screen.getByText('↓ 1000 B / ↑ 2000 B')).toBeInTheDocument()
     })
 
-    test('renders memory charts', () => {
+    test('renders memory charts even without limit', () => {
+      const metricsNoLimit = {
+        ...taskMetrics,
+        limit: 0,
+        usagePercent: 0,
+      }
+      render(
+        <TaskMetricsContent
+          taskMetrics={metricsNoLimit}
+          metricsLoading={false}
+          metricsError={null}
+        />
+      )
+
+      const cards = screen.getAllByTestId('mock-metric-card')
+      const memoryCard = cards.find((c) => c.getAttribute('data-title') === 'Memory Usage')
+      expect(memoryCard).toBeDefined()
+      // Should show donut chart even without limit (working set, cache, other used)
+      const charts = memoryCard.querySelectorAll('[data-testid="mock-chart"]')
+      expect(charts).toHaveLength(2)
+    })
+
+    test('renders memory charts with limit', () => {
       render(
         <TaskMetricsContent
           taskMetrics={taskMetrics}
@@ -299,10 +321,36 @@ describe('TaskMetricsContent', () => {
       expect(fsCard).toBeUndefined()
     })
 
-    test('shows CPU info alert when no quota configured', () => {
+    test('renders CPU gauge even without quota when has usage', () => {
+      const metricsWithUsageNoQuota = {
+        ...taskMetrics,
+        cpuPercent: 0,
+        cpuUsage: 123.456,
+        cpuUserSeconds: 0,
+        cpuSystemSeconds: 0,
+      }
+
+      render(
+        <TaskMetricsContent
+          taskMetrics={metricsWithUsageNoQuota}
+          metricsLoading={false}
+          metricsError={null}
+        />
+      )
+
+      const cards = screen.getAllByTestId('mock-metric-card')
+      const cpuCard = cards.find((c) => c.getAttribute('data-title') === 'CPU Usage')
+      expect(cpuCard).toBeDefined()
+      // Should show gauge chart even without quota
+      const charts = cpuCard.querySelectorAll('[data-testid="mock-chart"]')
+      expect(charts.length).toBeGreaterThanOrEqual(1)
+    })
+
+    test('shows no CPU data alert when no CPU data at all', () => {
       const metricsWithoutCPU = {
         ...taskMetrics,
         cpuPercent: 0,
+        cpuUsage: 0,
         cpuUserSeconds: 0,
         cpuSystemSeconds: 0,
       }
@@ -315,7 +363,7 @@ describe('TaskMetricsContent', () => {
         />
       )
 
-      expect(screen.getByText('CPU details not available (no quota configured)')).toBeInTheDocument()
+      expect(screen.getByText('No CPU data available')).toBeInTheDocument()
     })
 
     test('renders with dark mode', () => {
@@ -340,8 +388,9 @@ describe('TaskMetricsContent', () => {
       expect(screen.getByText('Container:')).toBeInTheDocument()
     })
 
-    test('hides CPU breakdown when no CPU data', () => {
-      const metricsWithoutCPU = {
+    test('hides CPU breakdown when no user/system data', () => {
+      // Has CPU usage but no user/system breakdown
+      const metricsWithoutBreakdown = {
         ...taskMetrics,
         cpuUserSeconds: 0,
         cpuSystemSeconds: 0,
@@ -349,7 +398,7 @@ describe('TaskMetricsContent', () => {
 
       render(
         <TaskMetricsContent
-          taskMetrics={metricsWithoutCPU}
+          taskMetrics={metricsWithoutBreakdown}
           metricsLoading={false}
           metricsError={null}
         />

--- a/app-src/tests/unit/components/tasks/details/cpuCharts.test.js
+++ b/app-src/tests/unit/components/tasks/details/cpuCharts.test.js
@@ -121,11 +121,51 @@ describe('cpuCharts', () => {
       expect(result.cpuBreakdownSeries).toEqual([0, 50])
     })
 
-    test('cpuGaugeOptions formatter function formats value correctly', () => {
-      const m = { cpuPercent: 50, cpuUserSeconds: 100, cpuSystemSeconds: 50 }
+    test('builds CPU charts without quota but with usage', () => {
+      const m = {
+        cpuPercent: 0,
+        cpuUsage: 123.456,
+        cpuUserSeconds: 50,
+        cpuSystemSeconds: 30,
+      }
+      const result = buildCPUCharts(m, commonOpts, false)
+
+      // Gauge should show 0 series value (empty gauge) when no quota
+      expect(result.cpuGaugeSeries).toEqual([0])
+      
+      // Label should show 'CPU Time' instead of 'CPU Quota'
+      expect(result.cpuGaugeOptions.labels).toEqual(['CPU Time'])
+      
+      // Formatter should show absolute CPU time
+      const formatter = result.cpuGaugeOptions.plotOptions.radialBar.dataLabels.value.formatter
+      expect(formatter(0)).toBe('123.46s')
+    })
+
+    test('builds CPU charts with zero usage and no quota', () => {
+      const m = {
+        cpuPercent: 0,
+        cpuUsage: 0,
+        cpuUserSeconds: 0,
+        cpuSystemSeconds: 0,
+      }
+      const result = buildCPUCharts(m, commonOpts, false)
+
+      expect(result.cpuGaugeSeries).toEqual([0])
+      expect(result.cpuGaugeOptions.labels).toEqual(['CPU Time'])
+    })
+
+    test('cpuGaugeOptions formatter function formats value correctly with quota', () => {
+      const m = { cpuPercent: 50, cpuUsage: 2.5, cpuUserSeconds: 100, cpuSystemSeconds: 50 }
       const result = buildCPUCharts(m, commonOpts, false)
       const formatter = result.cpuGaugeOptions.plotOptions.radialBar.dataLabels.value.formatter
       expect(formatter(75.123)).toBe('75.1%')
+    })
+
+    test('cpuGaugeOptions formatter shows absolute time without quota', () => {
+      const m = { cpuPercent: 0, cpuUsage: 123.456, cpuUserSeconds: 100, cpuSystemSeconds: 50 }
+      const result = buildCPUCharts(m, commonOpts, false)
+      const formatter = result.cpuGaugeOptions.plotOptions.radialBar.dataLabels.value.formatter
+      expect(formatter(0)).toBe('123.46s')
     })
 
     test('cpuBreakdownOptions dataLabels formatter formats value correctly', () => {

--- a/app-src/tests/unit/components/tasks/details/memoryCharts.test.js
+++ b/app-src/tests/unit/components/tasks/details/memoryCharts.test.js
@@ -204,15 +204,23 @@ describe('memoryCharts', () => {
 
     test('builds memory charts without limit', () => {
       const m = {
-        usagePercent: 50,
+        usagePercent: 0,
         memoryCache: 100,
         workingSet: 200,
         usage: 500
       }
       const result = buildMemoryCharts(m, commonOpts, false)
       
+      // Donut chart without limit should only have 3 categories (no Available)
       expect(result.memDonutOptions.labels).toEqual(['Working Set', 'Cache', 'Other Used'])
       expect(result.memDonutSeries).toEqual([200, 100, 200])
+      
+      // Gauge should show 0 series value (empty gauge) when no limit
+      expect(result.memGaugeSeries).toEqual([0])
+      
+      // Gauge formatter should show absolute usage value
+      const formatter = result.memGaugeOptions.plotOptions.radialBar.dataLabels.value.formatter
+      expect(formatter(0)).toBe('500 B')
     })
 
     test('builds memory charts with missing usagePercent', () => {


### PR DESCRIPTION
- Memory gauge shows absolute usage (e.g., '500 MB') when no limit set
- CPU gauge shows absolute time (e.g., '123.46s') when no quota set
- Donut charts only show 'Used' slice without limit
- Remove info alerts for missing limits - show charts instead
- Update tests for new behavior