### PR TITLE
Group react and react-dom updates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,11 @@ updates:
       - "automatic-merge"
     schedule:
       interval: "daily"
+    groups:
+      react-core:
+        patterns:
+          - "react"
+          - "react-dom"
 
   - package-ecosystem: "docker"
     directory: "/"


### PR DESCRIPTION
## Summary
This PR updates the Dependabot configuration to group `react` and `react-dom` updates together.

## Why
React 19 requires these two packages to have identical versions. By grouping them, Dependabot will create a single PR for both, preventing the version mismatch errors currently seen in CI (e.g., in #1087).

Fixes #1100