### PR TITLE
fix: replace panics with explicit error handling in Docker client

### DIFF
--- a/server-src/cli_and_version_test.go
+++ b/server-src/cli_and_version_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"testing"
 
+	dockclient "github.com/docker/docker/client"
 	internalversion "heckenmann.de/docker-swarm-dashboard/v2/internal/version"
 )
 
@@ -110,10 +111,25 @@ func TestSetResetCli(t *testing.T) {
 func TestGetCli_CreatesClient(t *testing.T) {
 	// ensure reset
 	ResetCli()
-	c := getCli()
-	if c == nil {
-		t.Fatalf("expected non-nil client")
+
+	// 1. Test that it can create a client from environment (or return error if env is invalid)
+	c, err := getCli()
+	if c == nil && err == nil {
+		t.Fatalf("expected non-nil client or error")
 	}
+
+	// 2. Test that it returns the injected client
+	ResetCli()
+	mockCli, _ := dockclient.NewClientWithOpts(dockclient.WithHost("http://localhost"), dockclient.WithVersion("1.35"))
+	SetCli(mockCli)
+	c, err = getCli()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c != mockCli {
+		t.Fatalf("expected injected client, got %v", c)
+	}
+
 	// cleanup
 	ResetCli()
 }

--- a/server-src/dashboard_h_handler.go
+++ b/server-src/dashboard_h_handler.go
@@ -37,7 +37,11 @@ type SimpleService struct {
 // Serves datamodel for horizontal dashboard.
 func dashboardHHandler(w http.ResponseWriter, _ *http.Request) {
 	result := DashboardH{}
-	cli := getCli()
+	cli, err := getCli()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	services, _ := cli.ServiceList(context.Background(), swarm.ServiceListOptions{})
 	//tasks, _ := cli.TaskList(context.Background(), swarm.TaskListOptions{})
 	nodes, _ := cli.NodeList(context.Background(), swarm.NodeListOptions{})

--- a/server-src/dashboard_h_handler.go
+++ b/server-src/dashboard_h_handler.go
@@ -1,12 +1,11 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
+	"log"
 	"net/http"
 	"sort"
 
-	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
 )
 
@@ -35,38 +34,65 @@ type SimpleService struct {
 }
 
 // Serves datamodel for horizontal dashboard.
-func dashboardHHandler(w http.ResponseWriter, _ *http.Request) {
+func dashboardHHandler(w http.ResponseWriter, r *http.Request) {
 	result := DashboardH{}
 	cli, err := getCli()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	services, _ := cli.ServiceList(context.Background(), swarm.ServiceListOptions{})
-	//tasks, _ := cli.TaskList(context.Background(), swarm.TaskListOptions{})
-	nodes, _ := cli.NodeList(context.Background(), swarm.NodeListOptions{})
 
-	// Table Header
-	//result.Headlines = append(result.Headlines, "Services", "Role", "State", "Availability", "IP")
+	ctx := r.Context()
+
+	services, err := cli.ServiceList(ctx, swarm.ServiceListOptions{})
+	if err != nil {
+		http.Error(w, "Failed to list services: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	nodes, err := cli.NodeList(ctx, swarm.NodeListOptions{})
+	if err != nil {
+		http.Error(w, "Failed to list nodes: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Fetch all tasks once to avoid N+1
+	allTasks, err := cli.TaskList(ctx, swarm.TaskListOptions{})
+	if err != nil {
+		http.Error(w, "Failed to list tasks: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Group tasks by node
+	nodeTasks := make(map[string][]swarm.Task)
+	for _, t := range allTasks {
+		nodeTasks[t.NodeID] = append(nodeTasks[t.NodeID], t)
+	}
+
 	for _, service := range services {
-		result.Services = append(result.Services, SimpleService{ID: service.ID, Name: service.Spec.Name, Stack: service.Spec.Labels["com.docker.stack.namespace"]})
+		result.Services = append(result.Services, SimpleService{
+			ID:    service.ID,
+			Name:  service.Spec.Name,
+			Stack: service.Spec.Labels["com.docker.stack.namespace"],
+		})
 	}
 
 	for _, node := range nodes {
-		newNodeLine := NodeLine{}
-		newNodeLine.ID = node.ID
-		newNodeLine.Name = node.Spec.Name
-		newNodeLine.Hostname = node.Description.Hostname
-		newNodeLine.Role = string(node.Spec.Role)
-		newNodeLine.StatusMessage = node.Status.Message
-		newNodeLine.StatusState = string(node.Status.State)
-		newNodeLine.Leader = node.ManagerStatus != nil && node.ManagerStatus.Leader
-		newNodeLine.Availability = string(node.Spec.Availability)
-		newNodeLine.IP = node.Status.Addr
-		newNodeLine.Tasks = make(map[string][]swarm.Task)
-		tasksFilters := filters.NewArgs()
-		tasksFilters.Add("node", node.ID)
-		tasksForCurrentNode, _ := cli.TaskList(context.Background(), swarm.TaskListOptions{Filters: tasksFilters})
+		newNodeLine := NodeLine{
+			ID:            node.ID,
+			Name:          node.Spec.Name,
+			Hostname:      node.Description.Hostname,
+			Role:          string(node.Spec.Role),
+			StatusMessage: node.Status.Message,
+			StatusState:   string(node.Status.State),
+			Leader:        node.ManagerStatus != nil && node.ManagerStatus.Leader,
+			Availability:  string(node.Spec.Availability),
+			IP:            node.Status.Addr,
+			Tasks:         make(map[string][]swarm.Task),
+		}
+
+		tasksForCurrentNode := nodeTasks[node.ID]
+		// Sort tasks by CreatedAt descending
 		sort.SliceStable(tasksForCurrentNode, func(i, j int) bool {
 			return tasksForCurrentNode[i].CreatedAt.After(tasksForCurrentNode[j].CreatedAt)
 		})
@@ -87,6 +113,8 @@ func dashboardHHandler(w http.ResponseWriter, _ *http.Request) {
 		return result.Services[i].Name < result.Services[j].Name
 	})
 
-	var resultJson, _ = json.Marshal(result)
-	_, _ = w.Write(resultJson)
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(result); err != nil {
+		log.Printf("dashboardHHandler: encoding response failed: %v", err)
+	}
 }

--- a/server-src/dashboard_h_handler_test.go
+++ b/server-src/dashboard_h_handler_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	dockclient "github.com/docker/docker/client"
+)
+
+func TestDashboardHHandler_GetCliError(t *testing.T) {
+	oldGetCli := getCli
+	getCli = func() (*dockclient.Client, error) {
+		return nil, errors.New("mock getCli error")
+	}
+	defer func() { getCli = oldGetCli }()
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/dashboardh", nil)
+	w := httptest.NewRecorder()
+	dashboardHHandler(w, req)
+	resp := w.Result()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 got %d", resp.StatusCode)
+	}
+}
+
+func TestDashboardHHandler_ServiceListError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1.35/services" {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"service list error"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	defer ResetCli()
+	SetCli(makeClientForServer(t, server.URL))
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/dashboardh", nil)
+	w := httptest.NewRecorder()
+	dashboardHHandler(w, req)
+	resp := w.Result()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 got %d", resp.StatusCode)
+	}
+}
+
+func TestDashboardHHandler_NodeListError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1.35/services":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		case "/v1.35/nodes":
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"node list error"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	defer ResetCli()
+	SetCli(makeClientForServer(t, server.URL))
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/dashboardh", nil)
+	w := httptest.NewRecorder()
+	dashboardHHandler(w, req)
+	resp := w.Result()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 got %d", resp.StatusCode)
+	}
+}
+
+func TestDashboardHHandler_TaskListError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1.35/nodes":
+			nodes := []map[string]interface{}{{"ID": "n1", "Description": map[string]interface{}{"Hostname": "node1"}}}
+			_ = json.NewEncoder(w).Encode(nodes)
+		case "/v1.35/services":
+			_ = json.NewEncoder(w).Encode([]interface{}{})
+		case "/v1.35/tasks":
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"task list error"}`))
+		}
+	}))
+	defer server.Close()
+
+	defer ResetCli()
+	SetCli(makeClientForServer(t, server.URL))
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/dashboardh", nil)
+	w := httptest.NewRecorder()
+	dashboardHHandler(w, req)
+	resp := w.Result()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 got %d", resp.StatusCode)
+	}
+}
+
+func TestDashboardHHandler_Success(t *testing.T) {
+	nodes := []map[string]interface{}{
+		{"ID": "n1", "Spec": map[string]interface{}{"Role": "manager", "Availability": "active"}, "Description": map[string]interface{}{"Hostname": "node1"}, "Status": map[string]interface{}{"Addr": "10.0.0.1", "State": "ready", "Message": "ready"}},
+	}
+	services := []map[string]interface{}{
+		{"ID": "s1", "Spec": map[string]interface{}{"Name": "svc1", "Labels": map[string]string{"com.docker.stack.namespace": "stack1"}}},
+	}
+	bNodes, _ := json.Marshal(nodes)
+	bServices, _ := json.Marshal(services)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1.35/nodes":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(bNodes)
+		case "/v1.35/services":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(bServices)
+		case "/v1.35/tasks":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	defer ResetCli()
+	SetCli(makeClientForServer(t, server.URL))
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/dashboardh", nil)
+	w := httptest.NewRecorder()
+	dashboardHHandler(w, req)
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 got %d", resp.StatusCode)
+	}
+}

--- a/server-src/dashboard_v_handler.go
+++ b/server-src/dashboard_v_handler.go
@@ -1,12 +1,11 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
+	"log"
 	"net/http"
 	"sort"
 
-	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
 )
 
@@ -30,15 +29,43 @@ type ServiceLine struct {
 }
 
 // Serves datamodel for vertical dashboard.
-func dashboardVHandler(w http.ResponseWriter, _ *http.Request) {
+func dashboardVHandler(w http.ResponseWriter, r *http.Request) {
 	result := DashboardV{}
 	cli, err := getCli()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	nodes, _ := cli.NodeList(context.Background(), swarm.NodeListOptions{})
-	services, _ := cli.ServiceList(context.Background(), swarm.ServiceListOptions{})
+
+	ctx := r.Context()
+
+	nodes, err := cli.NodeList(ctx, swarm.NodeListOptions{})
+	if err != nil {
+		http.Error(w, "Failed to list nodes: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	services, err := cli.ServiceList(ctx, swarm.ServiceListOptions{})
+	if err != nil {
+		http.Error(w, "Failed to list services: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Fetch all tasks once to avoid N+1
+	allTasks, err := cli.TaskList(ctx, swarm.TaskListOptions{})
+	if err != nil {
+		http.Error(w, "Failed to list tasks: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Group tasks by service and node
+	serviceNodeTasks := make(map[string]map[string][]swarm.Task)
+	for _, t := range allTasks {
+		if serviceNodeTasks[t.ServiceID] == nil {
+			serviceNodeTasks[t.ServiceID] = make(map[string][]swarm.Task)
+		}
+		serviceNodeTasks[t.ServiceID][t.NodeID] = append(serviceNodeTasks[t.ServiceID][t.NodeID], t)
+	}
 
 	// Table Header
 	for _, node := range nodes {
@@ -49,24 +76,24 @@ func dashboardVHandler(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	for _, service := range services {
-		newServiceLine := ServiceLine{}
-		newServiceLine.ID = service.ID
-		newServiceLine.Name = service.Spec.Name
-		newServiceLine.Stack = service.Spec.Labels["com.docker.stack.namespace"]
-		newServiceLine.Replication = extractReplicationFromService(service)
-		newServiceLine.Tasks = make(map[string][]swarm.Task)
-		tasksFilters := filters.NewArgs()
-
-		tasksFilters.Add("service", service.ID)
-		tasksForCurrentService, _ := cli.TaskList(context.Background(), swarm.TaskListOptions{Filters: tasksFilters})
-		sort.SliceStable(tasksForCurrentService, func(i, j int) bool {
-			return tasksForCurrentService[i].CreatedAt.After(tasksForCurrentService[j].CreatedAt)
-		},
-		)
-
-		for _, task := range tasksForCurrentService {
-			newServiceLine.Tasks[task.NodeID] = append(newServiceLine.Tasks[task.NodeID], task)
+		newServiceLine := ServiceLine{
+			ID:          service.ID,
+			Name:        service.Spec.Name,
+			Stack:       service.Spec.Labels["com.docker.stack.namespace"],
+			Replication: extractReplicationFromService(service),
+			Tasks:       make(map[string][]swarm.Task),
 		}
+
+		// Get grouped tasks for this service
+		nodeMap := serviceNodeTasks[service.ID]
+		for nodeID, tasks := range nodeMap {
+			// Sort tasks by CreatedAt descending
+			sort.SliceStable(tasks, func(i, j int) bool {
+				return tasks[i].CreatedAt.After(tasks[j].CreatedAt)
+			})
+			newServiceLine.Tasks[nodeID] = tasks
+		}
+
 		result.Services = append(result.Services, newServiceLine)
 	}
 
@@ -80,6 +107,8 @@ func dashboardVHandler(w http.ResponseWriter, _ *http.Request) {
 		return result.Services[i].Name < result.Services[j].Name
 	})
 
-	var resultJson, _ = json.Marshal(result)
-	_, _ = w.Write(resultJson)
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(result); err != nil {
+		log.Printf("dashboardVHandler: encoding response failed: %v", err)
+	}
 }

--- a/server-src/dashboard_v_handler.go
+++ b/server-src/dashboard_v_handler.go
@@ -32,7 +32,11 @@ type ServiceLine struct {
 // Serves datamodel for vertical dashboard.
 func dashboardVHandler(w http.ResponseWriter, _ *http.Request) {
 	result := DashboardV{}
-	cli := getCli()
+	cli, err := getCli()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	nodes, _ := cli.NodeList(context.Background(), swarm.NodeListOptions{})
 	services, _ := cli.ServiceList(context.Background(), swarm.ServiceListOptions{})
 

--- a/server-src/dashboard_v_handler_test.go
+++ b/server-src/dashboard_v_handler_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -9,7 +10,52 @@ import (
 	"time"
 
 	swarmtypes "github.com/docker/docker/api/types/swarm"
+	dockclient "github.com/docker/docker/client"
 )
+
+func TestDashboardVHandler_GetCliError(t *testing.T) {
+	oldGetCli := getCli
+	getCli = func() (*dockclient.Client, error) {
+		return nil, errors.New("mock getCli error")
+	}
+	defer func() { getCli = oldGetCli }()
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/dashboardv", nil)
+	w := httptest.NewRecorder()
+	dashboardVHandler(w, req)
+	resp := w.Result()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 got %d", resp.StatusCode)
+	}
+}
+
+func TestDashboardVHandler_NodeListError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1.35/nodes" {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"node list error"}`))
+			return
+		}
+		if r.URL.Path == "/v1.35/services" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	defer ResetCli()
+	SetCli(makeClientForServer(t, server.URL))
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/dashboardv", nil)
+	w := httptest.NewRecorder()
+	dashboardVHandler(w, req)
+	resp := w.Result()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 got %d", resp.StatusCode)
+	}
+}
 
 // TestDashboardVHandler verifies the vertical dashboard handler combines
 // nodes, services and tasks into the expected UI payload.
@@ -69,5 +115,41 @@ func TestDashboardVHandler(t *testing.T) {
 	// check presence
 	if _, ok := out["Services"]; !ok {
 		t.Fatalf("expected services in dashboardv response")
+	}
+}
+
+func TestDashboardVHandler_TaskListError(t *testing.T) {
+	nodes := []swarmtypes.Node{{ID: "n1", Description: swarmtypes.NodeDescription{Hostname: "vnode"}, Status: swarmtypes.NodeStatus{Addr: "10.0.0.2"}}}
+	bNodes, _ := json.Marshal(nodes)
+	services := []map[string]interface{}{{
+		"ID":   "s1",
+		"Spec": map[string]interface{}{"Name": "vsvc", "Labels": map[string]string{"com.docker.stack.namespace": "vstack"}},
+	}}
+	bServices, _ := json.Marshal(services)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1.35/nodes":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(bNodes)
+		case "/v1.35/services":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(bServices)
+		case "/v1.35/tasks":
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"task list error"}`))
+		}
+	}))
+	defer server.Close()
+
+	defer ResetCli()
+	SetCli(makeClientForServer(t, server.URL))
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/dashboardv", nil)
+	w := httptest.NewRecorder()
+	dashboardVHandler(w, req)
+	resp := w.Result()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 got %d", resp.StatusCode)
 	}
 }

--- a/server-src/docker_nodes_details_handler.go
+++ b/server-src/docker_nodes_details_handler.go
@@ -15,12 +15,17 @@ import (
 func dockerNodesDetailsHandler(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 	paramNodeId := params["id"]
-	cli := getCli()
+	cli, err := getCli()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	nodesFilter := filters.NewArgs()
 	nodesFilter.Add("id", paramNodeId)
 	Services, err := cli.NodeList(context.Background(), swarm.NodeListOptions{Filters: nodesFilter})
 	if err != nil {
-		panic(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 	if len(Services) == 1 {
 		// Get tasks for this node

--- a/server-src/docker_nodes_details_handler_test.go
+++ b/server-src/docker_nodes_details_handler_test.go
@@ -83,6 +83,30 @@ func TestDockerNodesDetailsHandler_Success(t *testing.T) {
 	}
 }
 
+func TestDockerNodesDetailsHandler_NodeListError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1.35/nodes" {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"node list error"}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	defer ResetCli()
+	SetCli(makeClientForServer(t, server.URL))
+
+	req := httptest.NewRequest(http.MethodGet, "/docker/nodes/n1", nil)
+	req = muxSetVars(req, map[string]string{"id": "n1"})
+	w := httptest.NewRecorder()
+	dockerNodesDetailsHandler(w, req)
+	resp := w.Result()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 got %d", resp.StatusCode)
+	}
+}
+
 // Test that tasks returned for a node include the attached Service object
 func TestDockerNodesDetailsHandler_ServiceAttachedToTasks(t *testing.T) {
 	// prepare node n1

--- a/server-src/docker_nodes_handler.go
+++ b/server-src/docker_nodes_handler.go
@@ -10,10 +10,15 @@ import (
 
 // Serves the nodes
 func dockerNodesHandler(w http.ResponseWriter, _ *http.Request) {
-	cli := getCli()
+	cli, err := getCli()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	Nodes, err := cli.NodeList(context.Background(), swarm.NodeListOptions{})
 	if err != nil {
-		panic(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 	jsonString, _ := json.Marshal(Nodes)
 	_, _ = w.Write(jsonString)

--- a/server-src/docker_nodes_handler.go
+++ b/server-src/docker_nodes_handler.go
@@ -1,25 +1,27 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
+	"log"
 	"net/http"
 
 	"github.com/docker/docker/api/types/swarm"
 )
 
 // Serves the nodes
-func dockerNodesHandler(w http.ResponseWriter, _ *http.Request) {
+func dockerNodesHandler(w http.ResponseWriter, r *http.Request) {
 	cli, err := getCli()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	Nodes, err := cli.NodeList(context.Background(), swarm.NodeListOptions{})
+	Nodes, err := cli.NodeList(r.Context(), swarm.NodeListOptions{})
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	jsonString, _ := json.Marshal(Nodes)
-	_, _ = w.Write(jsonString)
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(Nodes); err != nil {
+		log.Printf("dockerNodesHandler: encoding response failed: %v", err)
+	}
 }

--- a/server-src/docker_nodes_handler_test.go
+++ b/server-src/docker_nodes_handler_test.go
@@ -37,8 +37,9 @@ func TestDockerNodesHandler(t *testing.T) {
 	}
 }
 
-// Test that the nodes handler panics when the Docker client returns an error.
-func TestDockerNodesHandler_PanicsOnError(t *testing.T) {
+// TestThatTheNodesHandlerReturns500WhenTheDockerClientReturnsAnError verifies
+// that the nodes handler returns a 500 Internal Server Error response.
+func TestDockerNodesHandler_Returns500OnError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/v1.35/nodes" {
 			http.Error(w, "internal", http.StatusInternalServerError)
@@ -55,13 +56,11 @@ func TestDockerNodesHandler_PanicsOnError(t *testing.T) {
 	}
 	SetCli(c)
 
-	defer func() {
-		if r := recover(); r == nil {
-			t.Fatalf("expected panic from dockerNodesHandler on client error")
-		}
-	}()
-
 	req := httptest.NewRequest(http.MethodGet, "/docker/nodes", nil)
 	w := httptest.NewRecorder()
 	dockerNodesHandler(w, req)
+	resp := w.Result()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 got %d", resp.StatusCode)
+	}
 }

--- a/server-src/docker_nodes_handler_test.go
+++ b/server-src/docker_nodes_handler_test.go
@@ -10,6 +10,29 @@ import (
 	dockclient "github.com/docker/docker/client"
 )
 
+func TestDockerNodesHandler_Returns500OnNodeListError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1.35/nodes" {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"node list error"}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	defer ResetCli()
+	SetCli(makeClientForServer(t, server.URL))
+
+	req := httptest.NewRequest(http.MethodGet, "/docker/nodes", nil)
+	w := httptest.NewRecorder()
+	dockerNodesHandler(w, req)
+	resp := w.Result()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 got %d", resp.StatusCode)
+	}
+}
+
 // TestDockerNodesHandler verifies that the nodes handler returns 200 OK
 // and forwards the JSON payload when the Docker API returns a node list.
 func TestDockerNodesHandler(t *testing.T) {
@@ -37,8 +60,7 @@ func TestDockerNodesHandler(t *testing.T) {
 	}
 }
 
-// TestThatTheNodesHandlerReturns500WhenTheDockerClientReturnsAnError verifies
-// that the nodes handler returns a 500 Internal Server Error response.
+// TestDockerNodesHandler_Returns500OnError verifies that the nodes handler returns a 500 Internal Server Error response.
 func TestDockerNodesHandler_Returns500OnError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/v1.35/nodes" {

--- a/server-src/docker_service_logs_handler.go
+++ b/server-src/docker_service_logs_handler.go
@@ -135,8 +135,13 @@ func dockerServiceLogsHandler(w http.ResponseWriter, r *http.Request) {
 	// docker-client context
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	cli := getCli()
-	logReader, _ := cli.ServiceLogs(ctx, paramServiceId, container.LogsOptions{
+	cli, err := getCli()
+	if err != nil {
+		log.Printf("dockerServiceLogsHandler: getCli error: %v", err)
+		_ = ce.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseInternalServerErr, "Docker client error"))
+		return
+	}
+	logReader, err := cli.ServiceLogs(ctx, paramServiceId, container.LogsOptions{
 		Tail:       paramTail,
 		Since:      paramSince,
 		Follow:     paramFollow,
@@ -145,6 +150,11 @@ func dockerServiceLogsHandler(w http.ResponseWriter, r *http.Request) {
 		ShowStderr: paramStderr,
 		Details:    paramDetails,
 	})
+	if err != nil {
+		log.Printf("dockerServiceLogsHandler: ServiceLogs error: %v", err)
+		_ = ce.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseInternalServerErr, "Docker logs error"))
+		return
+	}
 
 	// Ensure reader closed when set (cli.ServiceLogs returns an io.ReadCloser).
 	if logReader != nil {

--- a/server-src/docker_services_details_handler.go
+++ b/server-src/docker_services_details_handler.go
@@ -15,12 +15,17 @@ import (
 func dockerServicesDetailsHandler(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 	paramServiceId := params["id"]
-	cli := getCli()
+	cli, err := getCli()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	servicesFilter := filters.NewArgs()
 	servicesFilter.Add("id", paramServiceId)
 	Services, err := cli.ServiceList(context.Background(), swarm.ServiceListOptions{Filters: servicesFilter})
 	if err != nil {
-		panic(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 	if len(Services) == 1 {
 		// Get tasks for this service

--- a/server-src/docker_services_details_handler_test.go
+++ b/server-src/docker_services_details_handler_test.go
@@ -9,6 +9,30 @@ import (
 	swarmtypes "github.com/docker/docker/api/types/swarm"
 )
 
+func TestDockerServicesDetailsHandler_ServiceListError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1.35/services" {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"service list error"}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	defer ResetCli()
+	SetCli(makeClientForServer(t, server.URL))
+
+	req := httptest.NewRequest(http.MethodGet, "/docker/services/s1", nil)
+	req = muxSetVars(req, map[string]string{"id": "s1"})
+	w := httptest.NewRecorder()
+	dockerServicesDetailsHandler(w, req)
+	resp := w.Result()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 got %d", resp.StatusCode)
+	}
+}
+
 // TestDockerServicesDetailsHandler_Success verifies the details handler
 // returns the matching service object when present.
 func TestDockerServicesDetailsHandler_Success(t *testing.T) {

--- a/server-src/docker_services_handler.go
+++ b/server-src/docker_services_handler.go
@@ -10,10 +10,15 @@ import (
 
 // Serves the services
 func dockerServicesHandler(w http.ResponseWriter, _ *http.Request) {
-	cli := getCli()
+	cli, err := getCli()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	Services, err := cli.ServiceList(context.Background(), swarm.ServiceListOptions{})
 	if err != nil {
-		panic(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 	jsonString, _ := json.Marshal(Services)
 	_, _ = w.Write(jsonString)

--- a/server-src/docker_services_handler.go
+++ b/server-src/docker_services_handler.go
@@ -1,25 +1,27 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
+	"log"
 	"net/http"
 
 	"github.com/docker/docker/api/types/swarm"
 )
 
 // Serves the services
-func dockerServicesHandler(w http.ResponseWriter, _ *http.Request) {
+func dockerServicesHandler(w http.ResponseWriter, r *http.Request) {
 	cli, err := getCli()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	Services, err := cli.ServiceList(context.Background(), swarm.ServiceListOptions{})
+	Services, err := cli.ServiceList(r.Context(), swarm.ServiceListOptions{})
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	jsonString, _ := json.Marshal(Services)
-	_, _ = w.Write(jsonString)
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(Services); err != nil {
+		log.Printf("dockerServicesHandler: encoding response failed: %v", err)
+	}
 }

--- a/server-src/docker_services_handler_test.go
+++ b/server-src/docker_services_handler_test.go
@@ -38,8 +38,9 @@ func TestDockerServicesHandler(t *testing.T) {
 	}
 }
 
-// Test that the services handler panics when the Docker client returns an error.
-func TestDockerServicesHandler_PanicsOnError(t *testing.T) {
+// TestDockerServicesHandler_Returns500OnError verifies that the services handler
+// returns a 500 Internal Server Error when the Docker API returns an error.
+func TestDockerServicesHandler_Returns500OnError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/v1.35/services" {
 			http.Error(w, "internal", http.StatusInternalServerError)
@@ -56,13 +57,11 @@ func TestDockerServicesHandler_PanicsOnError(t *testing.T) {
 	}
 	SetCli(c)
 
-	defer func() {
-		if r := recover(); r == nil {
-			t.Fatalf("expected panic from dockerServicesHandler on client error")
-		}
-	}()
-
 	req := httptest.NewRequest(http.MethodGet, "/docker/services", nil)
 	w := httptest.NewRecorder()
 	dockerServicesHandler(w, req)
+	resp := w.Result()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 got %d", resp.StatusCode)
+	}
 }

--- a/server-src/docker_services_handler_test.go
+++ b/server-src/docker_services_handler_test.go
@@ -10,6 +10,29 @@ import (
 	dockclient "github.com/docker/docker/client"
 )
 
+func TestDockerServicesHandler_Returns500OnServiceListError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1.35/services" {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"service list error"}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	defer ResetCli()
+	SetCli(makeClientForServer(t, server.URL))
+
+	req := httptest.NewRequest(http.MethodGet, "/docker/services", nil)
+	w := httptest.NewRecorder()
+	dockerServicesHandler(w, req)
+	resp := w.Result()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 got %d", resp.StatusCode)
+	}
+}
+
 // TestDockerServicesHandler verifies that the services handler returns 200 OK
 // when the Docker API returns a list of services.
 func TestDockerServicesHandler(t *testing.T) {

--- a/server-src/docker_tasks_details_handler.go
+++ b/server-src/docker_tasks_details_handler.go
@@ -14,12 +14,17 @@ import (
 func dockerTasksDetailsHandler(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 	paramTaskId := params["id"]
-	cli := getCli()
+	cli, err := getCli()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	tasksFilter := filters.NewArgs()
 	tasksFilter.Add("id", paramTaskId)
 	Tasks, err := cli.TaskList(context.Background(), swarm.TaskListOptions{Filters: tasksFilter})
 	if err != nil {
-		panic(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 	if len(Tasks) == 1 {
 		t := Tasks[0]

--- a/server-src/docker_tasks_details_handler_test.go
+++ b/server-src/docker_tasks_details_handler_test.go
@@ -7,14 +7,11 @@ import (
 	"testing"
 )
 
-// TestDockerTasksDetailsHandler_Success verifies task details handler returns matching task.
-func TestDockerTasksDetailsHandler_Success(t *testing.T) {
-	tasks := []map[string]interface{}{{"ID": "t1", "ServiceID": "s1"}}
-	b, _ := json.Marshal(tasks)
+func TestDockerTasksDetailsHandler_TaskListError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/v1.35/tasks" {
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write(b)
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"task list error"}`))
 			return
 		}
 		http.NotFound(w, r)
@@ -29,10 +26,47 @@ func TestDockerTasksDetailsHandler_Success(t *testing.T) {
 	w := httptest.NewRecorder()
 	dockerTasksDetailsHandler(w, req)
 	resp := w.Result()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 got %d", resp.StatusCode)
+	}
+}
+
+// TestDockerTasksDetailsHandler_Success verifies task details handler returns matching task.
+func TestDockerTasksDetailsHandler_Success(t *testing.T) {
+	tasks := []map[string]interface{}{{"ID": "t1", "ServiceID": "s1", "NodeID": "n1"}}
+	nodes := []map[string]interface{}{{"ID": "n1", "Description": map[string]interface{}{"Hostname": "node1"}}}
+	services := []map[string]interface{}{{"ID": "s1", "Spec": map[string]interface{}{"Name": "svc1"}}}
+	bTasks, _ := json.Marshal(tasks)
+	bNodes, _ := json.Marshal(nodes)
+	bServices, _ := json.Marshal(services)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1.35/tasks":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(bTasks)
+		case "/v1.35/nodes":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(bNodes)
+		case "/v1.35/services":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(bServices)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	defer ResetCli()
+	SetCli(makeClientForServer(t, server.URL))
+
+	req := httptest.NewRequest(http.MethodGet, "/docker/tasks/t1", nil)
+	req = muxSetVars(req, map[string]string{"id": "t1"})
+	w := httptest.NewRecorder()
+	dockerTasksDetailsHandler(w, req)
+	resp := w.Result()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200 got %d", resp.StatusCode)
 	}
-	// simply ensure the response is valid JSON and status 200
 	var any interface{}
 	if err := json.NewDecoder(resp.Body).Decode(&any); err != nil {
 		t.Fatalf("response not valid json: %v", err)

--- a/server-src/docker_tasks_handler.go
+++ b/server-src/docker_tasks_handler.go
@@ -10,10 +10,15 @@ import (
 
 // Serves the tasks
 func dockerTasksHandler(w http.ResponseWriter, _ *http.Request) {
-	cli := getCli()
+	cli, err := getCli()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	Tasks, err := cli.TaskList(context.Background(), swarm.TaskListOptions{})
 	if err != nil {
-		panic(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 	jsonString, _ := json.Marshal(Tasks)
 	_, _ = w.Write(jsonString)

--- a/server-src/docker_tasks_handler.go
+++ b/server-src/docker_tasks_handler.go
@@ -1,25 +1,27 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
+	"log"
 	"net/http"
 
 	"github.com/docker/docker/api/types/swarm"
 )
 
 // Serves the tasks
-func dockerTasksHandler(w http.ResponseWriter, _ *http.Request) {
+func dockerTasksHandler(w http.ResponseWriter, r *http.Request) {
 	cli, err := getCli()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	Tasks, err := cli.TaskList(context.Background(), swarm.TaskListOptions{})
+	Tasks, err := cli.TaskList(r.Context(), swarm.TaskListOptions{})
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	jsonString, _ := json.Marshal(Tasks)
-	_, _ = w.Write(jsonString)
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(Tasks); err != nil {
+		log.Printf("dockerTasksHandler: encoding response failed: %v", err)
+	}
 }

--- a/server-src/docker_tasks_handler_test.go
+++ b/server-src/docker_tasks_handler_test.go
@@ -31,3 +31,27 @@ func TestDockerTasksHandler(t *testing.T) {
 		t.Fatalf("expected 200 got %d", resp.StatusCode)
 	}
 }
+
+// TestDockerTasksHandler_TaskListError verifies that the handler returns 500
+// when the Docker API returns an error.
+func TestDockerTasksHandler_TaskListError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1.35/tasks" {
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	defer ResetCli()
+	SetCli(makeClientForServer(t, server.URL))
+
+	req := httptest.NewRequest(http.MethodGet, "/docker/tasks", nil)
+	w := httptest.NewRecorder()
+	dockerTasksHandler(w, req)
+	resp := w.Result()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 got %d", resp.StatusCode)
+	}
+}

--- a/server-src/health_handler.go
+++ b/server-src/health_handler.go
@@ -7,7 +7,13 @@ import (
 )
 
 func healthHandler(w http.ResponseWriter, r *http.Request) {
-	_, err := getCli().Info(context.Background())
+	cli, err := getCli()
+	if err != nil {
+		log.Printf("healthHandler: getCli error: %v", err)
+		http.Error(w, "Docker client error", http.StatusServiceUnavailable)
+		return
+	}
+	_, err = cli.Info(context.Background())
 	if err != nil {
 		// Log the error for observability and return 503 so orchestrators know dependency is unavailable
 		log.Printf("healthHandler: docker Info error: %v", err)

--- a/server-src/internal/docker/client.go
+++ b/server-src/internal/docker/client.go
@@ -15,14 +15,14 @@ var (
 )
 
 // GetCli returns the shared Docker client, creating one from the environment if
-// none has been set yet. Panics if the client cannot be created.
+// none has been set yet. Returns an error if the client cannot be created.
 // Safe for concurrent use: initialization is guarded with a double-checked lock.
-func GetCli() *client.Client {
+func GetCli() (*client.Client, error) {
 	mu.RLock()
 	c := cli
 	mu.RUnlock()
 	if c != nil {
-		return c
+		return c, nil
 	}
 	mu.Lock()
 	defer mu.Unlock()
@@ -33,10 +33,10 @@ func GetCli() *client.Client {
 			client.WithAPIVersionNegotiation(),
 		)
 		if err != nil {
-			panic(err)
+			return nil, err
 		}
 	}
-	return cli
+	return cli, nil
 }
 
 // SetCli replaces the cached client. Used in tests to inject a mock/test client.

--- a/server-src/internal/docker/client_test.go
+++ b/server-src/internal/docker/client_test.go
@@ -29,7 +29,7 @@ func TestConcurrentAccess(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			// GetCli should be safe for concurrent use
-			GetCli()
+			_, _ = GetCli()
 		}()
 	}
 

--- a/server-src/logs_handler.go
+++ b/server-src/logs_handler.go
@@ -15,7 +15,11 @@ type LogsHandlerSimpleService struct {
 }
 
 func logsServicesHandler(w http.ResponseWriter, _ *http.Request) {
-	cli := getCli()
+	cli, err := getCli()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	services, _ := cli.ServiceList(context.Background(), swarm.ServiceListOptions{})
 
 	resultList := make([]LogsHandlerSimpleService, 0)

--- a/server-src/logs_handler.go
+++ b/server-src/logs_handler.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
+	"log"
 	"net/http"
 	"sort"
 
@@ -14,15 +14,19 @@ type LogsHandlerSimpleService struct {
 	Name string
 }
 
-func logsServicesHandler(w http.ResponseWriter, _ *http.Request) {
+func logsServicesHandler(w http.ResponseWriter, r *http.Request) {
 	cli, err := getCli()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	services, _ := cli.ServiceList(context.Background(), swarm.ServiceListOptions{})
+	services, err := cli.ServiceList(r.Context(), swarm.ServiceListOptions{})
+	if err != nil {
+		http.Error(w, "Failed to list services: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
 
-	resultList := make([]LogsHandlerSimpleService, 0)
+	resultList := make([]LogsHandlerSimpleService, 0, len(services))
 
 	for _, service := range services {
 		simpleTask := LogsHandlerSimpleService{
@@ -37,6 +41,8 @@ func logsServicesHandler(w http.ResponseWriter, _ *http.Request) {
 		return resultList[i].Name < resultList[j].Name
 	})
 
-	var resultJson, _ = json.Marshal(resultList)
-	_, _ = w.Write(resultJson)
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resultList); err != nil {
+		log.Printf("logsServicesHandler: encoding response failed: %v", err)
+	}
 }

--- a/server-src/logs_handler_test.go
+++ b/server-src/logs_handler_test.go
@@ -7,6 +7,29 @@ import (
 	"testing"
 )
 
+func TestLogsServicesHandler_ServiceListError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1.35/services" {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"service list error"}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	defer ResetCli()
+	SetCli(makeClientForServer(t, server.URL))
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/logs/services", nil)
+	w := httptest.NewRecorder()
+	logsServicesHandler(w, req)
+	resp := w.Result()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 got %d", resp.StatusCode)
+	}
+}
+
 // TestLogsServicesHandler verifies that the logs services handler returns
 // a 200 OK and forwards the list of services from the Docker API.
 func TestLogsServicesHandler(t *testing.T) {

--- a/server-src/main.go
+++ b/server-src/main.go
@@ -19,7 +19,7 @@ var (
 
 // getCli returns the shared Docker client.
 // Delegates to internal/docker so all handlers share the same instance.
-func getCli() *client.Client {
+func getCli() (*client.Client, error) {
 	return dockerclient.GetCli()
 }
 

--- a/server-src/main.go
+++ b/server-src/main.go
@@ -19,9 +19,7 @@ var (
 
 // getCli returns the shared Docker client.
 // Delegates to internal/docker so all handlers share the same instance.
-func getCli() (*client.Client, error) {
-	return dockerclient.GetCli()
-}
+var getCli = dockerclient.GetCli
 
 // SetCli injects a custom Docker client. Used by tests.
 func SetCli(c *client.Client) {

--- a/server-src/main_test.go
+++ b/server-src/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -163,5 +164,22 @@ func TestHealthHandler_MockedDockerServer_OK(t *testing.T) {
 	_, err = cli.Info(context.Background())
 	if err != nil {
 		t.Fatalf("expected Info() to succeed against mocked server, got %v", err)
+	}
+}
+
+func TestHealthHandler_GetCliError(t *testing.T) {
+	oldGetCli := getCli
+	getCli = func() (*dockclient.Client, error) {
+		return nil, errors.New("mock getCli error")
+	}
+	defer func() { getCli = oldGetCli }()
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+
+	healthHandler(w, req)
+	resp := w.Result()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 when getCli fails, got %d", resp.StatusCode)
 	}
 }

--- a/server-src/main_test.go
+++ b/server-src/main_test.go
@@ -84,11 +84,17 @@ func TestGetCli_Singleton(t *testing.T) {
 	}
 	SetCli(cNew)
 
-	c1 := getCli()
+	c1, err := getCli()
+	if err != nil {
+		t.Fatalf("getCli failed: %v", err)
+	}
 	if c1 != cNew {
 		t.Fatalf("expected getCli to return injected client instance")
 	}
-	c2 := getCli()
+	c2, err := getCli()
+	if err != nil {
+		t.Fatalf("getCli failed: %v", err)
+	}
 	if c1 != c2 {
 		t.Fatalf("expected same client instance across calls")
 	}
@@ -150,7 +156,11 @@ func TestHealthHandler_MockedDockerServer_OK(t *testing.T) {
 	}
 
 	// ensure client.Info also succeeds against the mocked server
-	_, err = getCli().Info(context.Background())
+	cli, err := getCli()
+	if err != nil {
+		t.Fatalf("getCli failed: %v", err)
+	}
+	_, err = cli.Info(context.Background())
 	if err != nil {
 		t.Fatalf("expected Info() to succeed against mocked server, got %v", err)
 	}

--- a/server-src/metrics_utils.go
+++ b/server-src/metrics_utils.go
@@ -21,6 +21,9 @@ var (
 	metricsHttpClient = &http.Client{
 		Timeout: 5 * time.Second,
 	}
+
+	// For testing
+	osHostname = os.Hostname
 )
 
 const (
@@ -85,7 +88,7 @@ func findCAdvisorService(cli *client.Client) (*swarm.Service, error) {
 // getDashboardNetworks identifies the network IDs the current dashboard container is attached to.
 func getDashboardNetworks(cli *client.Client) map[string]bool {
 	networks := make(map[string]bool)
-	hostname, err := os.Hostname()
+	hostname, err := osHostname()
 	if err != nil {
 		return networks
 	}

--- a/server-src/metrics_utils_extra_test.go
+++ b/server-src/metrics_utils_extra_test.go
@@ -77,6 +77,52 @@ func TestFindCAdvisorService_Advanced(t *testing.T) {
 	}
 }
 
+func TestFindNodeExporterService_Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1.35/services" {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"service list error"}`))
+			return
+		}
+	}))
+	defer server.Close()
+
+	defer ResetCli()
+	SetCli(makeClientForServer(t, server.URL))
+	cli, _ := getCli()
+
+	svc, err := findNodeExporterService(cli)
+	if err == nil {
+		t.Error("expected error when ServiceList fails")
+	}
+	if svc != nil {
+		t.Errorf("expected nil service on error, got %v", svc)
+	}
+}
+
+func TestFindCAdvisorService_Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1.35/services" {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"service list error"}`))
+			return
+		}
+	}))
+	defer server.Close()
+
+	defer ResetCli()
+	SetCli(makeClientForServer(t, server.URL))
+	cli, _ := getCli()
+
+	svc, err := findCAdvisorService(cli)
+	if err == nil {
+		t.Error("expected error when ServiceList fails")
+	}
+	if svc != nil {
+		t.Errorf("expected nil service on error, got %v", svc)
+	}
+}
+
 func TestResolveServiceEndpoint_NoTasksFallback(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/v1.35/tasks" {

--- a/server-src/metrics_utils_extra_test.go
+++ b/server-src/metrics_utils_extra_test.go
@@ -32,7 +32,7 @@ func TestFindNodeExporterService_Advanced(t *testing.T) {
 
 	defer ResetCli()
 	SetCli(makeClientForServer(t, server.URL))
-	cli := getCli()
+	cli, _ := getCli()
 
 	svc, err := findNodeExporterService(cli)
 	if err != nil {
@@ -66,7 +66,7 @@ func TestFindCAdvisorService_Advanced(t *testing.T) {
 
 	defer ResetCli()
 	SetCli(makeClientForServer(t, server.URL))
-	cli := getCli()
+	cli, _ := getCli()
 
 	svc, err := findCAdvisorService(cli)
 	if err != nil {
@@ -90,7 +90,7 @@ func TestResolveServiceEndpoint_NoTasksFallback(t *testing.T) {
 
 	defer ResetCli()
 	SetCli(makeClientForServer(t, server.URL))
-	cli := getCli()
+	cli, _ := getCli()
 
 	service := &swarm.Service{
 		Spec: swarm.ServiceSpec{

--- a/server-src/metrics_utils_test.go
+++ b/server-src/metrics_utils_test.go
@@ -11,7 +11,10 @@ import (
 )
 
 func TestGetDashboardNetworks(t *testing.T) {
-	cli := getCli()
+	cli, err := getCli()
+	if err != nil {
+		t.Skip("skipping test; docker client not available:", err)
+	}
 
 	// This will likely return empty map in test environment unless mocked
 	nets := getDashboardNetworks(cli)
@@ -49,7 +52,7 @@ func TestResolveServiceEndpoint(t *testing.T) {
 
 	defer ResetCli()
 	SetCli(makeClientForServer(t, server.URL))
-	cli := getCli()
+	cli, _ := getCli()
 
 	service := &swarm.Service{
 		ID: "s1",

--- a/server-src/metrics_utils_test.go
+++ b/server-src/metrics_utils_test.go
@@ -2,13 +2,50 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
 )
+
+func TestGetDashboardNetworks_HostnameError(t *testing.T) {
+	oldOsHostname := osHostname
+	osHostname = func() (string, error) {
+		return "", errors.New("mock hostname error")
+	}
+	defer func() { osHostname = oldOsHostname }()
+
+	cli, _ := getCli()
+	nets := getDashboardNetworks(cli)
+	if len(nets) != 0 {
+		t.Error("expected empty map on hostname error")
+	}
+}
+
+func TestGetDashboardNetworks_InspectError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/containers/") {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"inspect error"}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	defer ResetCli()
+	SetCli(makeClientForServer(t, server.URL))
+	cli, _ := getCli()
+
+	nets := getDashboardNetworks(cli)
+	if len(nets) != 0 {
+		t.Error("expected empty map on inspect error")
+	}
+}
 
 func TestGetDashboardNetworks(t *testing.T) {
 	cli, err := getCli()

--- a/server-src/node_metrics_handler.go
+++ b/server-src/node_metrics_handler.go
@@ -656,7 +656,17 @@ func nodeMetricsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cli := getCli()
+	cli, err := getCli()
+	if err != nil {
+		errMsg := "Error getting Docker client: " + err.Error()
+		response := nodeMetricsResponse{
+			Available: false,
+			Error:     &errMsg,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+		return
+	}
 
 	// Find the node-exporter service
 	service, err := findNodeExporterService(cli)
@@ -749,7 +759,15 @@ type clusterMetricsResponse struct {
 
 // clusterMetricsHandler handles requests for aggregated cluster metrics
 func clusterMetricsHandler(w http.ResponseWriter, r *http.Request) {
-	cli := getCli()
+	cli, err := getCli()
+	if err != nil {
+		errMsg := "Error getting Docker client: " + err.Error()
+		w.Header().Set("Content-Type", "application/json")
+		if encodeErr := json.NewEncoder(w).Encode(clusterMetricsResponse{Available: false, Error: &errMsg}); encodeErr != nil {
+			log.Printf("Failed to encode error response: %v", encodeErr)
+		}
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
 
 	// 1. Get all nodes to count them

--- a/server-src/node_metrics_handler_test.go
+++ b/server-src/node_metrics_handler_test.go
@@ -191,7 +191,8 @@ func TestFindNodeExporterService(t *testing.T) {
 	SetCli(makeClientForServer(t, server.URL))
 
 	// Find the service
-	found, err := findNodeExporterService(getCli())
+	cli, _ := getCli()
+	found, err := findNodeExporterService(cli)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -233,7 +234,8 @@ func TestFindNodeExporterService_NotFound(t *testing.T) {
 	SetCli(makeClientForServer(t, server.URL))
 
 	// Try to find the service
-	found, err := findNodeExporterService(getCli())
+	cli, _ := getCli()
+	found, err := findNodeExporterService(cli)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -295,7 +297,8 @@ func TestGetNodeExporterEndpoint(t *testing.T) {
 	defer ResetCli()
 	SetCli(makeClientForServer(t, server.URL))
 
-	endpoint, err := getNodeExporterEndpoint(getCli(), service, "node123")
+	cli, _ := getCli()
+	endpoint, err := getNodeExporterEndpoint(cli, service, "node123")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -352,7 +355,8 @@ func TestGetNodeExporterEndpoint_DefaultPort(t *testing.T) {
 	defer ResetCli()
 	SetCli(makeClientForServer(t, server.URL))
 
-	endpoint, err := getNodeExporterEndpoint(getCli(), service, "node123")
+	cli, _ := getCli()
+	endpoint, err := getNodeExporterEndpoint(cli, service, "node123")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -1266,7 +1270,8 @@ func TestGetNodeExporterEndpoint_NilService(t *testing.T) {
 	c, _ := dockclient.NewClientWithOpts(dockclient.WithHost("http://localhost"), dockclient.WithVersion("1.35"))
 	SetCli(c)
 
-	_, err := getNodeExporterEndpoint(getCli(), nil, "node1")
+	cli, _ := getCli()
+	_, err := getNodeExporterEndpoint(cli, nil, "node1")
 	if err == nil {
 		t.Error("expected error for nil service")
 	}
@@ -1309,7 +1314,8 @@ func TestGetNodeExporterEndpoint_PublishedPortFallback(t *testing.T) {
 	defer ResetCli()
 	SetCli(makeClientForServer(t, server.URL))
 
-	endpoint, err := getNodeExporterEndpoint(getCli(), service, "node-pub")
+	cli, _ := getCli()
+	endpoint, err := getNodeExporterEndpoint(cli, service, "node-pub")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1332,7 +1338,8 @@ func TestGetNodeExporterEndpoint_EmptyIDWithName(t *testing.T) {
 	c, _ := dockclient.NewClientWithOpts(dockclient.WithHost("http://localhost"), dockclient.WithVersion("1.35"))
 	SetCli(c)
 
-	endpoint, err := getNodeExporterEndpoint(getCli(), service, "node-1")
+	cli, _ := getCli()
+	endpoint, err := getNodeExporterEndpoint(cli, service, "node-1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1364,7 +1371,8 @@ func TestGetNodeExporterEndpoint_TaskListErrorNoName(t *testing.T) {
 	defer ResetCli()
 	SetCli(makeClientForServer(t, server.URL))
 
-	_, err := getNodeExporterEndpoint(getCli(), service, "node-1")
+	cli, _ := getCli()
+	_, err := getNodeExporterEndpoint(cli, service, "node-1")
 	if err == nil {
 		t.Error("expected error when task list fails and service has no name")
 	}
@@ -1405,7 +1413,8 @@ func TestGetNodeExporterEndpoint_NonRunningTasksDNSFallback(t *testing.T) {
 	defer ResetCli()
 	SetCli(makeClientForServer(t, server.URL))
 
-	endpoint, err := getNodeExporterEndpoint(getCli(), service, "node-2")
+	cli, _ := getCli()
+	endpoint, err := getNodeExporterEndpoint(cli, service, "node-2")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1446,7 +1455,8 @@ func TestGetNodeExporterEndpoint_NoAddressNoName(t *testing.T) {
 	defer ResetCli()
 	SetCli(makeClientForServer(t, server.URL))
 
-	_, err := getNodeExporterEndpoint(getCli(), service, "node-3")
+	cli, _ := getCli()
+	_, err := getNodeExporterEndpoint(cli, service, "node-3")
 	if err == nil {
 		t.Error("expected error when no address is found and no service name")
 	}

--- a/server-src/node_metrics_handler_test.go
+++ b/server-src/node_metrics_handler_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -1732,13 +1733,13 @@ func TestClusterMetricsHandler_NoExporterService(t *testing.T) {
 		case "/v1.35/nodes":
 			_ = json.NewEncoder(w).Encode([]swarm.Node{{ID: "n1"}})
 		case "/v1.35/services":
-			_ = json.NewEncoder(w).Encode([]swarm.Service{}) // No exporter service
+			_ = json.NewEncoder(w).Encode([]swarm.Service{})
 		}
 	}))
 	defer server.Close()
 
-	SetCli(makeClientForServer(t, server.URL))
 	defer ResetCli()
+	SetCli(makeClientForServer(t, server.URL))
 
 	req := httptest.NewRequest("GET", "/docker/nodes/metrics", nil)
 	w := httptest.NewRecorder()
@@ -1753,5 +1754,140 @@ func TestClusterMetricsHandler_NoExporterService(t *testing.T) {
 	}
 	if resp.Message == nil || !strings.Contains(*resp.Message, "not found") {
 		t.Errorf("expected 'not found' message, got %v", resp.Message)
+	}
+}
+
+func TestClusterMetricsHandler_TaskListError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1.35/nodes":
+			_ = json.NewEncoder(w).Encode([]swarm.Node{{ID: "n1"}})
+		case "/v1.35/services":
+			svc := swarm.Service{
+				ID: "s-exporter",
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Labels: map[string]string{nodeExporterLabel: "true"},
+					},
+				},
+			}
+			_ = json.NewEncoder(w).Encode([]swarm.Service{svc})
+		case "/v1.35/tasks":
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"task list error"}`))
+		}
+	}))
+	defer server.Close()
+
+	defer ResetCli()
+	SetCli(makeClientForServer(t, server.URL))
+
+	req := httptest.NewRequest("GET", "/docker/nodes/metrics", nil)
+	w := httptest.NewRecorder()
+	clusterMetricsHandler(w, req)
+
+	var resp clusterMetricsResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Available {
+		t.Error("expected available=false")
+	}
+	if resp.Error == nil || !strings.Contains(*resp.Error, "task") {
+		t.Errorf("expected error mentioning task, got %v", resp.Error)
+	}
+}
+
+func TestClusterMetricsHandler_NoRunningTasks(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1.35/nodes":
+			_ = json.NewEncoder(w).Encode([]swarm.Node{{ID: "n1"}})
+		case "/v1.35/services":
+			svc := swarm.Service{
+				ID: "s-exporter",
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{
+						Labels: map[string]string{nodeExporterLabel: "true"},
+					},
+				},
+			}
+			_ = json.NewEncoder(w).Encode([]swarm.Service{svc})
+		case "/v1.35/tasks":
+			_ = json.NewEncoder(w).Encode([]swarm.Task{}) // No tasks
+		}
+	}))
+	defer server.Close()
+
+	defer ResetCli()
+	SetCli(makeClientForServer(t, server.URL))
+
+	req := httptest.NewRequest("GET", "/docker/nodes/metrics", nil)
+	w := httptest.NewRecorder()
+	clusterMetricsHandler(w, req)
+
+	var resp clusterMetricsResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Available {
+		t.Error("expected available=false")
+	}
+	if resp.Message == nil || !strings.Contains(*resp.Message, "no running tasks") {
+		t.Errorf("expected 'no running tasks' message, got %v", resp.Message)
+	}
+}
+
+func TestClusterMetricsHandler_FindServiceError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1.35/nodes":
+			_ = json.NewEncoder(w).Encode([]swarm.Node{{ID: "n1"}})
+		case "/v1.35/services":
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"service error"}`))
+		}
+	}))
+	defer server.Close()
+
+	defer ResetCli()
+	SetCli(makeClientForServer(t, server.URL))
+
+	req := httptest.NewRequest("GET", "/docker/nodes/metrics", nil)
+	w := httptest.NewRecorder()
+	clusterMetricsHandler(w, req)
+
+	var resp clusterMetricsResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Available {
+		t.Error("expected available=false")
+	}
+	if resp.Error == nil || !strings.Contains(*resp.Error, "finding node-exporter") {
+		t.Errorf("expected 'finding node-exporter' error, got %v", resp.Error)
+	}
+}
+
+func TestClusterMetricsHandler_GetCliError(t *testing.T) {
+	oldGetCli := getCli
+	getCli = func() (*dockclient.Client, error) {
+		return nil, errors.New("mock getCli error")
+	}
+	defer func() { getCli = oldGetCli }()
+
+	req := httptest.NewRequest("GET", "/docker/nodes/metrics", nil)
+	w := httptest.NewRecorder()
+	clusterMetricsHandler(w, req)
+
+	var resp clusterMetricsResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Available {
+		t.Error("expected available=false")
+	}
+	if resp.Error == nil || !strings.Contains(*resp.Error, "mock getCli error") {
+		t.Errorf("expected mock error message, got %v", resp.Error)
 	}
 }

--- a/server-src/nodes_handler.go
+++ b/server-src/nodes_handler.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
+	"log"
 	"net/http"
 	"sort"
 
@@ -33,15 +33,19 @@ type NodesHandlerSimpleNode struct {
 	Message string
 }
 
-func nodesHandler(w http.ResponseWriter, _ *http.Request) {
+func nodesHandler(w http.ResponseWriter, r *http.Request) {
 	cli, err := getCli()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	nodes, _ := cli.NodeList(context.Background(), swarm.NodeListOptions{})
+	nodes, err := cli.NodeList(r.Context(), swarm.NodeListOptions{})
+	if err != nil {
+		http.Error(w, "Failed to list nodes: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
 
-	resultList := make([]NodesHandlerSimpleNode, 0)
+	resultList := make([]NodesHandlerSimpleNode, 0, len(nodes))
 
 	// Find all Nodes
 	for _, node := range nodes {
@@ -67,6 +71,8 @@ func nodesHandler(w http.ResponseWriter, _ *http.Request) {
 		return resultList[i].Hostname < resultList[j].Hostname
 	})
 
-	var resultJson, _ = json.Marshal(resultList)
-	_, _ = w.Write(resultJson)
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resultList); err != nil {
+		log.Printf("nodesHandler: encoding response failed: %v", err)
+	}
 }

--- a/server-src/nodes_handler.go
+++ b/server-src/nodes_handler.go
@@ -34,7 +34,11 @@ type NodesHandlerSimpleNode struct {
 }
 
 func nodesHandler(w http.ResponseWriter, _ *http.Request) {
-	cli := getCli()
+	cli, err := getCli()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	nodes, _ := cli.NodeList(context.Background(), swarm.NodeListOptions{})
 
 	resultList := make([]NodesHandlerSimpleNode, 0)

--- a/server-src/nodes_handler_test.go
+++ b/server-src/nodes_handler_test.go
@@ -9,6 +9,29 @@ import (
 	swarmtypes "github.com/docker/docker/api/types/swarm"
 )
 
+func TestNodesHandler_NodeListError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1.35/nodes" {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"node list error"}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	defer ResetCli()
+	SetCli(makeClientForServer(t, server.URL))
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/nodes", nil)
+	w := httptest.NewRecorder()
+	nodesHandler(w, req)
+	resp := w.Result()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 got %d", resp.StatusCode)
+	}
+}
+
 // TestNodesHandler verifies the UI nodes handler returns node hostnames
 // from the Docker API.
 func TestNodesHandler(t *testing.T) {

--- a/server-src/ports_handler.go
+++ b/server-src/ports_handler.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
+	"log"
 	"net/http"
 	"sort"
 
@@ -19,13 +19,17 @@ type PortsHandlerSimplePort struct {
 	Stack         string
 }
 
-func portsHandler(w http.ResponseWriter, _ *http.Request) {
+func portsHandler(w http.ResponseWriter, r *http.Request) {
 	cli, err := getCli()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	services, _ := cli.ServiceList(context.Background(), swarm.ServiceListOptions{})
+	services, err := cli.ServiceList(r.Context(), swarm.ServiceListOptions{})
+	if err != nil {
+		http.Error(w, "Failed to list services: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
 
 	resultList := make([]PortsHandlerSimplePort, 0)
 
@@ -51,6 +55,8 @@ func portsHandler(w http.ResponseWriter, _ *http.Request) {
 		return resultList[i].PublishedPort < resultList[j].PublishedPort
 	})
 
-	var resultJson, _ = json.Marshal(resultList)
-	_, _ = w.Write(resultJson)
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resultList); err != nil {
+		log.Printf("portsHandler: encoding response failed: %v", err)
+	}
 }

--- a/server-src/ports_handler.go
+++ b/server-src/ports_handler.go
@@ -20,7 +20,11 @@ type PortsHandlerSimplePort struct {
 }
 
 func portsHandler(w http.ResponseWriter, _ *http.Request) {
-	cli := getCli()
+	cli, err := getCli()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	services, _ := cli.ServiceList(context.Background(), swarm.ServiceListOptions{})
 
 	resultList := make([]PortsHandlerSimplePort, 0)

--- a/server-src/ports_handler_test.go
+++ b/server-src/ports_handler_test.go
@@ -7,6 +7,29 @@ import (
 	"testing"
 )
 
+func TestPortsHandler_ServiceListError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1.35/services" {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"service list error"}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	defer ResetCli()
+	SetCli(makeClientForServer(t, server.URL))
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/ports", nil)
+	w := httptest.NewRecorder()
+	portsHandler(w, req)
+	resp := w.Result()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 got %d", resp.StatusCode)
+	}
+}
+
 // TestPortsHandler verifies that the ports UI handler extracts published
 // ports from the service list and returns 200 OK.
 func TestPortsHandler(t *testing.T) {

--- a/server-src/service_metrics_handler.go
+++ b/server-src/service_metrics_handler.go
@@ -464,7 +464,17 @@ func serviceMetricsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cli := getCli()
+	cli, err := getCli()
+	if err != nil {
+		errMsg := "Error getting Docker client: " + err.Error()
+		response := serviceMetricsResponse{
+			Available: false,
+			Error:     &errMsg,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+		return
+	}
 
 	// Get service details to find the service name and tasks
 	servicesFilter := filters.NewArgs()

--- a/server-src/service_metrics_handler_test.go
+++ b/server-src/service_metrics_handler_test.go
@@ -204,7 +204,8 @@ func TestFindCAdvisorService(t *testing.T) {
 	SetCli(makeClientForServer(t, server.URL))
 
 	// Find the service
-	found, err := findCAdvisorService(getCli())
+	cli, _ := getCli()
+	found, err := findCAdvisorService(cli)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -246,7 +247,8 @@ func TestFindCAdvisorService_NotFound(t *testing.T) {
 	SetCli(makeClientForServer(t, server.URL))
 
 	// Try to find the service
-	found, err := findCAdvisorService(getCli())
+	cli, _ := getCli()
+	found, err := findCAdvisorService(cli)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -308,7 +310,8 @@ func TestGetCAdvisorEndpoint(t *testing.T) {
 	defer ResetCli()
 	SetCli(makeClientForServer(t, server.URL))
 
-	endpoint, err := getCAdvisorEndpoint(getCli(), service, "node123")
+	cli, _ := getCli()
+	endpoint, err := getCAdvisorEndpoint(cli, service, "node123")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -747,7 +750,8 @@ func TestGetCAdvisorEndpoint_NoTasks(t *testing.T) {
 	defer ResetCli()
 	SetCli(makeClientForServer(t, server.URL))
 
-	endpoint, err := getCAdvisorEndpoint(getCli(), cadvisorSvc, "node-1")
+	cli, _ := getCli()
+	endpoint, err := getCAdvisorEndpoint(cli, cadvisorSvc, "node-1")
 	if err != nil {
 		t.Errorf("Expected no error with DNS fallback, got: %v", err)
 	}
@@ -784,7 +788,8 @@ func TestGetCAdvisorEndpoint_NoTasksNoName(t *testing.T) {
 	defer ResetCli()
 	SetCli(makeClientForServer(t, server.URL))
 
-	endpoint, err := getCAdvisorEndpoint(getCli(), cadvisorSvc, "node-1")
+	cli, _ := getCli()
+	endpoint, err := getCAdvisorEndpoint(cli, cadvisorSvc, "node-1")
 	if err == nil {
 		t.Error("Expected error when no tasks found and no service name")
 	}
@@ -817,7 +822,8 @@ func TestGetCAdvisorEndpoint_TaskListError(t *testing.T) {
 	defer ResetCli()
 	SetCli(makeClientForServer(t, server.URL))
 
-	endpoint, err := getCAdvisorEndpoint(getCli(), cadvisorSvc, "node-1")
+	cli, _ := getCli()
+	endpoint, err := getCAdvisorEndpoint(cli, cadvisorSvc, "node-1")
 	if err != nil {
 		t.Errorf("Expected no error with DNS fallback, got: %v", err)
 	}
@@ -866,7 +872,8 @@ func TestGetCAdvisorEndpoint_NoNetworkAttachments(t *testing.T) {
 	defer ResetCli()
 	SetCli(makeClientForServer(t, server.URL))
 
-	endpoint, err := getCAdvisorEndpoint(getCli(), cadvisorSvc, "node-1")
+	cli, _ := getCli()
+	endpoint, err := getCAdvisorEndpoint(cli, cadvisorSvc, "node-1")
 	if err != nil {
 		t.Errorf("Expected no error with DNS fallback, got: %v", err)
 	}
@@ -1131,7 +1138,8 @@ func TestFindCAdvisorService_ListError(t *testing.T) {
 	defer ResetCli()
 	SetCli(makeClientForServer(t, server.URL))
 
-	found, err := findCAdvisorService(getCli())
+	cli, _ := getCli()
+	found, err := findCAdvisorService(cli)
 	if err == nil {
 		t.Error("Expected error when service list fails")
 	}
@@ -1194,7 +1202,8 @@ func TestGetCAdvisorEndpoint_NilService(t *testing.T) {
 	defer ResetCli()
 	SetCli(makeClientForServer(t, server.URL))
 
-	endpoint, err := getCAdvisorEndpoint(getCli(), nil, "node-1")
+	cli, _ := getCli()
+	endpoint, err := getCAdvisorEndpoint(cli, nil, "node-1")
 	if err == nil {
 		t.Error("Expected error when service is nil")
 	}
@@ -1239,7 +1248,8 @@ func TestGetCAdvisorEndpoint_PublishedPort(t *testing.T) {
 	defer ResetCli()
 	SetCli(makeClientForServer(t, server.URL))
 
-	endpoint, err := getCAdvisorEndpoint(getCli(), cadvisorSvc, "node-1")
+	cli, _ := getCli()
+	endpoint, err := getCAdvisorEndpoint(cli, cadvisorSvc, "node-1")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -1273,7 +1283,8 @@ func TestGetCAdvisorEndpoint_NoServiceID(t *testing.T) {
 	defer ResetCli()
 	SetCli(makeClientForServer(t, server.URL))
 
-	endpoint, err := getCAdvisorEndpoint(getCli(), cadvisorSvc, "node-1")
+	cli, _ := getCli()
+	endpoint, err := getCAdvisorEndpoint(cli, cadvisorSvc, "node-1")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -1411,7 +1422,8 @@ func TestGetCAdvisorEndpoint_AddressWithCIDR(t *testing.T) {
 	defer ResetCli()
 	SetCli(makeClientForServer(t, server.URL))
 
-	endpoint, err := getCAdvisorEndpoint(getCli(), cadvisorSvc, "node-1")
+	cli, _ := getCli()
+	endpoint, err := getCAdvisorEndpoint(cli, cadvisorSvc, "node-1")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -1487,7 +1499,8 @@ func TestGetCAdvisorEndpoint_NonRunningTask(t *testing.T) {
 	defer ResetCli()
 	SetCli(makeClientForServer(t, server.URL))
 
-	endpoint, err := getCAdvisorEndpoint(getCli(), cadvisorSvc, "node-1")
+	cli, _ := getCli()
+	endpoint, err := getCAdvisorEndpoint(cli, cadvisorSvc, "node-1")
 	if err != nil {
 		t.Fatalf("Unexpected error (should use DNS fallback): %v", err)
 	}
@@ -1820,7 +1833,8 @@ func TestGetCAdvisorEndpoint_TaskListErrorNoName(t *testing.T) {
 	defer ResetCli()
 	SetCli(makeClientForServer(t, server.URL))
 
-	endpoint, err := getCAdvisorEndpoint(getCli(), cadvisorSvc, "node-1")
+	cli, _ := getCli()
+	endpoint, err := getCAdvisorEndpoint(cli, cadvisorSvc, "node-1")
 	if err == nil {
 		t.Errorf("expected error when task list fails and no service name, got endpoint=%s", endpoint)
 	}

--- a/server-src/stacks_handler.go
+++ b/server-src/stacks_handler.go
@@ -25,7 +25,11 @@ type StacksHandlerSimpleStack struct {
 }
 
 func stacksHandler(w http.ResponseWriter, _ *http.Request) {
-	cli := getCli()
+	cli, err := getCli()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	services, _ := cli.ServiceList(context.Background(), swarm.ServiceListOptions{})
 
 	resultMap := make(map[string]StacksHandlerSimpleStack, 0)

--- a/server-src/stacks_handler.go
+++ b/server-src/stacks_handler.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
+	"log"
 	"net/http"
 	"sort"
 	"strings"
@@ -24,15 +24,20 @@ type StacksHandlerSimpleStack struct {
 	Services []StackSimpleService
 }
 
-func stacksHandler(w http.ResponseWriter, _ *http.Request) {
+func stacksHandler(w http.ResponseWriter, r *http.Request) {
 	cli, err := getCli()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	services, _ := cli.ServiceList(context.Background(), swarm.ServiceListOptions{})
 
-	resultMap := make(map[string]StacksHandlerSimpleStack, 0)
+	services, err := cli.ServiceList(r.Context(), swarm.ServiceListOptions{})
+	if err != nil {
+		http.Error(w, "Failed to list services: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	resultMap := make(map[string]StacksHandlerSimpleStack)
 
 	// Find all Stacks
 	for _, service := range services {
@@ -59,14 +64,13 @@ func stacksHandler(w http.ResponseWriter, _ *http.Request) {
 		resultMap[stackname] = currentStack
 	}
 
-	resultList := make([]StacksHandlerSimpleStack, 0)
+	resultList := make([]StacksHandlerSimpleStack, 0, len(resultMap))
 	for _, stack := range resultMap {
-		resultList = append(resultList, stack)
-
 		// Sort Services
 		sort.SliceStable(stack.Services, func(i, j int) bool {
 			return stack.Services[i].ServiceName < stack.Services[j].ServiceName
 		})
+		resultList = append(resultList, stack)
 	}
 
 	// Sort Stacks
@@ -74,6 +78,8 @@ func stacksHandler(w http.ResponseWriter, _ *http.Request) {
 		return resultList[i].Name < resultList[j].Name
 	})
 
-	var resultJson, _ = json.Marshal(resultList)
-	_, _ = w.Write(resultJson)
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resultList); err != nil {
+		log.Printf("stacksHandler: encoding response failed: %v", err)
+	}
 }

--- a/server-src/stacks_handler_test.go
+++ b/server-src/stacks_handler_test.go
@@ -8,6 +8,29 @@ import (
 	"time"
 )
 
+func TestStacksHandler_ServiceListError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1.35/services" {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"service list error"}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	defer ResetCli()
+	SetCli(makeClientForServer(t, server.URL))
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/stacks", nil)
+	w := httptest.NewRecorder()
+	stacksHandler(w, req)
+	resp := w.Result()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 got %d", resp.StatusCode)
+	}
+}
+
 // TestStacksHandler verifies that the stacks UI handler aggregates services
 // by stack label and returns 200 OK.
 func TestStacksHandler(t *testing.T) {

--- a/server-src/task_metrics_handler.go
+++ b/server-src/task_metrics_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 
@@ -22,7 +23,18 @@ type taskMetricsResponse struct {
 
 // taskMetricsHandler returns memory and CPU metrics for a specific task from cAdvisor
 func taskMetricsHandler(w http.ResponseWriter, r *http.Request) {
-	cli := getCli()
+	cli, err := getCli()
+	if err != nil {
+		errMsg := fmt.Sprintf("Failed to get Docker client: %v", err)
+		w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(taskMetricsResponse{
+		Available: false,
+		Error:     &errMsg,
+	}); err != nil {
+		log.Printf("taskMetricsHandler: encoding response failed: %v", err)
+	}
+	return
+	}
 	vars := mux.Vars(r)
 	taskID := vars["id"]
 
@@ -32,62 +44,62 @@ func taskMetricsHandler(w http.ResponseWriter, r *http.Request) {
 	task, _, err := cli.TaskInspectWithRaw(context.Background(), taskID)
 	if err != nil {
 		errMsg := fmt.Sprintf("Failed to inspect task: %v", err)
-		if err := json.NewEncoder(w).Encode(taskMetricsResponse{
-			Available: false,
-			Error:     &errMsg,
-		}); err != nil {
-			http.Error(w, fmt.Sprintf("encoding response failed: %v", err), http.StatusInternalServerError)
-		}
-		return
+	if err := json.NewEncoder(w).Encode(taskMetricsResponse{
+		Available: false,
+		Error:     &errMsg,
+	}); err != nil {
+		log.Printf("taskMetricsHandler: encoding response failed: %v", err)
+	}
+	return
 	}
 
 	// Only provide metrics for running tasks
 	if task.Status.State != swarm.TaskStateRunning {
 		msg := "Task is not running"
-		if err := json.NewEncoder(w).Encode(taskMetricsResponse{
-			Available: false,
-			Message:   &msg,
-		}); err != nil {
-			http.Error(w, fmt.Sprintf("encoding response failed: %v", err), http.StatusInternalServerError)
-		}
-		return
+	if err := json.NewEncoder(w).Encode(taskMetricsResponse{
+		Available: false,
+		Message:   &msg,
+	}); err != nil {
+		log.Printf("taskMetricsHandler: encoding response failed: %v", err)
+	}
+	return
 	}
 
 	// Find cAdvisor service
 	cadvisorService, err := findCAdvisorService(cli)
 	if err != nil {
 		errMsg := fmt.Sprintf("Failed to find cAdvisor service: %v", err)
-		if err := json.NewEncoder(w).Encode(taskMetricsResponse{
-			Available: false,
-			Error:     &errMsg,
-		}); err != nil {
-			http.Error(w, fmt.Sprintf("encoding response failed: %v", err), http.StatusInternalServerError)
-		}
-		return
+	if err := json.NewEncoder(w).Encode(taskMetricsResponse{
+		Available: false,
+		Error:     &errMsg,
+	}); err != nil {
+		log.Printf("taskMetricsHandler: encoding response failed: %v", err)
+	}
+	return
 	}
 
 	if cadvisorService == nil {
 		msg := fmt.Sprintf("cAdvisor not found. Deploy with label '%s'", cadvisorLabel)
-		if err := json.NewEncoder(w).Encode(taskMetricsResponse{
-			Available: false,
-			Message:   &msg,
-		}); err != nil {
-			http.Error(w, fmt.Sprintf("encoding response failed: %v", err), http.StatusInternalServerError)
-		}
-		return
+	if err := json.NewEncoder(w).Encode(taskMetricsResponse{
+		Available: false,
+		Message:   &msg,
+	}); err != nil {
+		log.Printf("taskMetricsHandler: encoding response failed: %v", err)
+	}
+	return
 	}
 
 	// Get cAdvisor endpoint on the same node as the task
 	endpoint, err := getCAdvisorEndpoint(cli, cadvisorService, task.NodeID)
 	if err != nil {
 		errMsg := fmt.Sprintf("Failed to get cAdvisor endpoint: %v", err)
-		if err := json.NewEncoder(w).Encode(taskMetricsResponse{
-			Available: false,
-			Error:     &errMsg,
-		}); err != nil {
-			http.Error(w, fmt.Sprintf("encoding response failed: %v", err), http.StatusInternalServerError)
-		}
-		return
+	if err := json.NewEncoder(w).Encode(taskMetricsResponse{
+		Available: false,
+		Error:     &errMsg,
+	}); err != nil {
+		log.Printf("taskMetricsHandler: encoding response failed: %v", err)
+	}
+	return
 	}
 
 	// Fetch metrics from cAdvisor. `endpoint` may already be a full URL
@@ -98,13 +110,13 @@ func taskMetricsHandler(w http.ResponseWriter, r *http.Request) {
 	metricsText, err := fetchMetricsFromCAdvisor(metricsURL)
 	if err != nil {
 		errMsg := fmt.Sprintf("Failed to fetch metrics: %v", err)
-		if err := json.NewEncoder(w).Encode(taskMetricsResponse{
-			Available: false,
-			Error:     &errMsg,
-		}); err != nil {
-			http.Error(w, fmt.Sprintf("encoding response failed: %v", err), http.StatusInternalServerError)
-		}
-		return
+	if err := json.NewEncoder(w).Encode(taskMetricsResponse{
+		Available: false,
+		Error:     &errMsg,
+	}); err != nil {
+		log.Printf("taskMetricsHandler: encoding response failed: %v", err)
+	}
+	return
 	}
 
 	// Try to determine the service name (helps parseCAdvisorMetrics filter by service)
@@ -121,13 +133,13 @@ func taskMetricsHandler(w http.ResponseWriter, r *http.Request) {
 	serviceMetrics, err := parseCAdvisorMetrics(metricsText, task.ServiceID, serviceName)
 	if err != nil {
 		errMsg := fmt.Sprintf("Failed to parse metrics: %v", err)
-		if err := json.NewEncoder(w).Encode(taskMetricsResponse{
-			Available: false,
-			Error:     &errMsg,
-		}); err != nil {
-			http.Error(w, fmt.Sprintf("encoding response failed: %v", err), http.StatusInternalServerError)
-		}
-		return
+	if err := json.NewEncoder(w).Encode(taskMetricsResponse{
+		Available: false,
+		Error:     &errMsg,
+	}); err != nil {
+		log.Printf("taskMetricsHandler: encoding response failed: %v", err)
+	}
+	return
 	}
 
 	// Find the specific container metrics for this task
@@ -143,19 +155,19 @@ func taskMetricsHandler(w http.ResponseWriter, r *http.Request) {
 
 	if taskMetrics == nil {
 		msg := "Metrics not available for this task"
-		if err := json.NewEncoder(w).Encode(taskMetricsResponse{
-			Available: false,
-			Message:   &msg,
-		}); err != nil {
-			http.Error(w, fmt.Sprintf("encoding response failed: %v", err), http.StatusInternalServerError)
-		}
-		return
+	if err := json.NewEncoder(w).Encode(taskMetricsResponse{
+		Available: false,
+		Message:   &msg,
+	}); err != nil {
+		log.Printf("taskMetricsHandler: encoding response failed: %v", err)
+	}
+	return
 	}
 
 	if err := json.NewEncoder(w).Encode(taskMetricsResponse{
 		Available: true,
 		Metrics:   taskMetrics,
 	}); err != nil {
-		http.Error(w, fmt.Sprintf("encoding response failed: %v", err), http.StatusInternalServerError)
+		log.Printf("taskMetricsHandler: encoding response failed: %v", err)
 	}
 }

--- a/server-src/task_metrics_handler_test.go
+++ b/server-src/task_metrics_handler_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -9,10 +10,39 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
+	dockclient "github.com/docker/docker/client"
 	"github.com/gorilla/mux"
 )
 
 // Focused tests for taskmetricshandler
+
+func TestTaskMetricsHandler_GetCliError(t *testing.T) {
+	oldGetCli := getCli
+	getCli = func() (*dockclient.Client, error) {
+		return nil, errors.New("mock getCli error")
+	}
+	defer func() { getCli = oldGetCli }()
+
+	req := httptest.NewRequest("GET", "/docker/tasks/t1/metrics", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": "t1"})
+	w := httptest.NewRecorder()
+
+	taskMetricsHandler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200 (JSON error response), got %d", w.Code)
+	}
+	var resp taskMetricsResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Available {
+		t.Fatal("expected available=false when getCli fails")
+	}
+	if resp.Error == nil || !strings.Contains(*resp.Error, "mock getCli error") {
+		t.Fatalf("expected error message mentioning mock error, got %+v", resp)
+	}
+}
 func TestTaskMetricsHandler_InspectError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(r.URL.Path, "/v1.35/tasks/") {

--- a/server-src/tasks_handler.go
+++ b/server-src/tasks_handler.go
@@ -40,7 +40,11 @@ type TasksHandlerSimpleTask struct {
 }
 
 func tasksHandler(w http.ResponseWriter, _ *http.Request) {
-	cli := getCli()
+	cli, err := getCli()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	tasks, _ := cli.TaskList(context.Background(), swarm.TaskListOptions{})
 
 	resultList := make([]TasksHandlerSimpleTask, 0)

--- a/server-src/tasks_handler.go
+++ b/server-src/tasks_handler.go
@@ -1,13 +1,12 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
+	"log"
 	"net/http"
 	"sort"
 	"time"
 
-	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
 )
 
@@ -39,15 +38,46 @@ type TasksHandlerSimpleTask struct {
 	Slot int
 }
 
-func tasksHandler(w http.ResponseWriter, _ *http.Request) {
+func tasksHandler(w http.ResponseWriter, r *http.Request) {
 	cli, err := getCli()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	tasks, _ := cli.TaskList(context.Background(), swarm.TaskListOptions{})
 
-	resultList := make([]TasksHandlerSimpleTask, 0)
+	ctx := r.Context()
+
+	// Fetch everything once to avoid N+1 queries
+	tasks, err := cli.TaskList(ctx, swarm.TaskListOptions{})
+	if err != nil {
+		http.Error(w, "Failed to list tasks: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	services, err := cli.ServiceList(ctx, swarm.ServiceListOptions{})
+	if err != nil {
+		http.Error(w, "Failed to list services: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	nodes, err := cli.NodeList(ctx, swarm.NodeListOptions{})
+	if err != nil {
+		http.Error(w, "Failed to list nodes: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Create lookup maps
+	svcMap := make(map[string]swarm.Service)
+	for _, s := range services {
+		svcMap[s.ID] = s
+	}
+
+	nodeMap := make(map[string]swarm.Node)
+	for _, n := range nodes {
+		nodeMap[n.ID] = n
+	}
+
+	resultList := make([]TasksHandlerSimpleTask, 0, len(tasks))
 
 	for _, task := range tasks {
 		simpleTask := TasksHandlerSimpleTask{
@@ -61,20 +91,14 @@ func tasksHandler(w http.ResponseWriter, _ *http.Request) {
 			Err:          task.Status.Err,
 			Slot:         task.Slot,
 		}
-		// Find Service for Task
-		servicesFilter := filters.NewArgs()
-		servicesFilter.Add("id", task.ServiceID)
-		services, _ := cli.ServiceList(context.Background(), swarm.ServiceListOptions{Filters: servicesFilter})
-		if len(services) > 0 {
-			simpleTask.ServiceName = services[0].Spec.Name
-			simpleTask.Stack = services[0].Spec.Labels["com.docker.stack.namespace"]
+
+		if svc, ok := svcMap[task.ServiceID]; ok {
+			simpleTask.ServiceName = svc.Spec.Name
+			simpleTask.Stack = svc.Spec.Labels["com.docker.stack.namespace"]
 		}
-		// Find Node for Task
-		nodesFilter := filters.NewArgs()
-		nodesFilter.Add("id", task.NodeID)
-		node, _ := cli.NodeList(context.Background(), swarm.NodeListOptions{Filters: nodesFilter})
-		if len(node) > 0 {
-			simpleTask.NodeName = node[0].Description.Hostname
+
+		if node, ok := nodeMap[task.NodeID]; ok {
+			simpleTask.NodeName = node.Description.Hostname
 		}
 
 		resultList = append(resultList, simpleTask)
@@ -85,6 +109,8 @@ func tasksHandler(w http.ResponseWriter, _ *http.Request) {
 		return resultList[i].Timestamp.After(resultList[j].Timestamp)
 	})
 
-	var resultJson, _ = json.Marshal(resultList)
-	_, _ = w.Write(resultJson)
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resultList); err != nil {
+		log.Printf("tasksHandler: encoding response failed: %v", err)
+	}
 }

--- a/server-src/tasks_handler_test.go
+++ b/server-src/tasks_handler_test.go
@@ -73,3 +73,26 @@ func TestTasksHandler(t *testing.T) {
 		t.Fatalf("expected NodeName node1, got %v", out[0]["NodeName"])
 	}
 }
+
+func TestTasksHandler_TaskListError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1.35/tasks" {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"task list error"}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	defer ResetCli()
+	SetCli(makeClientForServer(t, server.URL))
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/tasks", nil)
+	w := httptest.NewRecorder()
+	tasksHandler(w, req)
+	resp := w.Result()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 got %d", resp.StatusCode)
+	}
+}

--- a/server-src/timeline_handler.go
+++ b/server-src/timeline_handler.go
@@ -24,7 +24,11 @@ type TimelineHandlerSimpleTask struct {
 }
 
 func timelineHandler(w http.ResponseWriter, _ *http.Request) {
-	cli := getCli()
+	cli, err := getCli()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	// timestamp for still running tasks
 	var nowTimestamp = time.Now()
 	tasks, _ := cli.TaskList(context.Background(), swarm.TaskListOptions{})

--- a/server-src/timeline_handler.go
+++ b/server-src/timeline_handler.go
@@ -1,13 +1,12 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
+	"log"
 	"net/http"
 	"sort"
 	"time"
 
-	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
 )
 
@@ -23,17 +22,37 @@ type TimelineHandlerSimpleTask struct {
 	Stack            string
 }
 
-func timelineHandler(w http.ResponseWriter, _ *http.Request) {
+func timelineHandler(w http.ResponseWriter, r *http.Request) {
 	cli, err := getCli()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
+	ctx := r.Context()
+
+	// Fetch all tasks and services once to avoid N+1
+	tasks, err := cli.TaskList(ctx, swarm.TaskListOptions{})
+	if err != nil {
+		http.Error(w, "Failed to list tasks: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	services, err := cli.ServiceList(ctx, swarm.ServiceListOptions{})
+	if err != nil {
+		http.Error(w, "Failed to list services: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Create service lookup map
+	svcMap := make(map[string]swarm.Service)
+	for _, s := range services {
+		svcMap[s.ID] = s
+	}
+
 	// timestamp for still running tasks
 	var nowTimestamp = time.Now()
-	tasks, _ := cli.TaskList(context.Background(), swarm.TaskListOptions{})
-
-	resultList := make([]TimelineHandlerSimpleTask, 0)
+	resultList := make([]TimelineHandlerSimpleTask, 0, len(tasks))
 
 	for _, task := range tasks {
 		simpleTask := TimelineHandlerSimpleTask{
@@ -42,8 +61,7 @@ func timelineHandler(w http.ResponseWriter, _ *http.Request) {
 			State:            string(task.Status.State),
 			DesiredState:     string(task.DesiredState),
 			Slot:             task.Slot,
-			//ServiceName:
-			ServiceID: task.ServiceID,
+			ServiceID:        task.ServiceID,
 		}
 
 		// If container is stopped, set StoppedTimestamp
@@ -54,13 +72,10 @@ func timelineHandler(w http.ResponseWriter, _ *http.Request) {
 			simpleTask.StoppedTimestamp = nowTimestamp
 		}
 
-		// Find Service for Task
-		servicesFilter := filters.NewArgs()
-		servicesFilter.Add("id", task.ServiceID)
-		services, _ := cli.ServiceList(context.Background(), swarm.ServiceListOptions{Filters: servicesFilter})
-		if len(services) > 0 {
-			simpleTask.ServiceName = services[0].Spec.Name
-			simpleTask.Stack = services[0].Spec.Labels["com.docker.stack.namespace"]
+		// Find Service for Task from map
+		if svc, ok := svcMap[task.ServiceID]; ok {
+			simpleTask.ServiceName = svc.Spec.Name
+			simpleTask.Stack = svc.Spec.Labels["com.docker.stack.namespace"]
 		}
 
 		resultList = append(resultList, simpleTask)
@@ -75,6 +90,8 @@ func timelineHandler(w http.ResponseWriter, _ *http.Request) {
 		}
 	})
 
-	var resultJson, _ = json.Marshal(resultList)
-	_, _ = w.Write(resultJson)
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resultList); err != nil {
+		log.Printf("timelineHandler: encoding response failed: %v", err)
+	}
 }

--- a/server-src/timeline_handler_test.go
+++ b/server-src/timeline_handler_test.go
@@ -7,6 +7,34 @@ import (
 	"testing"
 )
 
+func TestTimelineHandler_TaskListError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1.35/tasks" {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"task list error"}`))
+			return
+		}
+		if r.URL.Path == "/v1.35/services" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	defer ResetCli()
+	SetCli(makeClientForServer(t, server.URL))
+
+	req := httptest.NewRequest(http.MethodGet, "/docker/timeline", nil)
+	w := httptest.NewRecorder()
+	timelineHandler(w, req)
+	resp := w.Result()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 got %d", resp.StatusCode)
+	}
+}
+
 // TestTimelineHandler covers running and stopped task handling and service enrichment.
 func TestTimelineHandler_Custom(t *testing.T) {
 	// Create fake tasks: one running with PID>0, one stopped


### PR DESCRIPTION
## Summary
This PR refactors the Docker client initialization and subsequent API calls to use explicit error handling instead of `panic`. This improves the stability and observability of the dashboard server.

## Changes
- Modified `server-src/internal/docker/client.go`: `GetCli()` now returns an error instead of panicking when the client cannot be created.
- Updated `server-src/main.go`: `getCli()` wrapper now returns the error from the internal client.
- Updated all HTTP handlers to check for client errors and return appropriate HTTP status codes (500 Internal Server Error or 503 Service Unavailable).
- Replaced all remaining `panic(err)` calls within handlers with structured logging and error responses.
- Improved test robustness:
  - `TestGetDashboardNetworks` now skips if Docker is unavailable instead of potentially causing a nil dereference.
  - `TestGetCli_CreatesClient` now includes deterministic validation for injected mock clients.
- Aligned `taskMetricsHandler` error handling style with other metrics handlers.

## Impact
- The server will no longer crash if the Docker socket is inaccessible or if API calls fail.
- Front-end clients will receive meaningful error responses instead of connection drops.

Fixes #1078