### PR TITLE
Add configurable origin policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Docker Swarm Dashboard supports environment variables for configuration.
 | `DSD_DASHBOARD_LAYOUT` | Default dashboard layout. Either `row` (default) or `column`. | `row` |
 | `DSD_HIDE_SERVICE_STATES` | Comma-separated list of states to not show in the main dashboard. | (none) |
 | `DSD_PATH_PREFIX` | Set a URL path prefix for the dashboard (e.g. `/dashboard`). Useful when running behind a reverse proxy or when the app should not be served from the root path. | `/` |
+| `DSD_ALLOWED_ORIGINS` | Comma-separated list of allowed HTTP CORS and WebSocket origins (e.g. `https://dashboard.example.com`). The default keeps the historical behavior and allows all origins. Set a concrete allow-list to restrict browser access. | `*` |
 | `DSD_NODE_EXPORTER_LABEL` | Docker service label to identify node-exporter service for metrics collection. | `dsd.node-exporter` |
 | `DSD_CADVISOR_LABEL` | Docker service label to identify cAdvisor service for container memory metrics. | `dsd.cadvisor` |
 | `LOCALE` | Timestamp format based on a [BCP 47](https://www.rfc-editor.org/bcp/bcp47.txt) language tag. | (system) |
@@ -72,6 +73,8 @@ Docker Swarm Dashboard supports environment variables for configuration.
 | `DSD_VERSION_CHECK_CACHE_TIMEOUT_MINUTES` | Cache duration in minutes for version check results. | `60` |
 | `DSD_WELCOME_MESSAGE` | If set, this message will be displayed to the user in a modal dialog when the web application is opened in the browser. | (none) |
 | `DOCKER_API_VERSION` | Forces a specific Docker API version to use (e.g. `1.35`, `1.41`). When not specified, the server automatically negotiates the highest API version supported by both the client and Docker daemon. Only set this if you need to force a specific version for compatibility. | (auto-negotiated) |
+
+If `DSD_ALLOWED_ORIGINS` is not set, the server logs a startup warning because all HTTP CORS and WebSocket origins are allowed for backward compatibility.
 
 #### UI Default Settings
 These environment variables control the default UI state. All settings can be changed by the user in the web interface and are persisted in the URL hash.

--- a/server-src/docker_service_logs_handler.go
+++ b/server-src/docker_service_logs_handler.go
@@ -20,12 +20,9 @@ import (
 
 var (
 	// upgrader configures the websocket upgrade and enables compression.
-	// CheckOrigin returns true to allow connections from any origin.
 	upgrader = websocket.Upgrader{
 		EnableCompression: true,
-		CheckOrigin: func(_ *http.Request) bool {
-			return true
-		},
+		CheckOrigin:       isWebSocketOriginAllowed,
 	}
 )
 

--- a/server-src/main.go
+++ b/server-src/main.go
@@ -33,6 +33,7 @@ func ResetCli() {
 
 func main() {
 	log.Println("Starting Docker Swarm Dashboard...")
+	warnIfAllowedOriginsUnset()
 	log.Println("Starting server setup")
 	handler := buildHandler()
 	log.Println("Ready! Waiting for connections on port " + httpPort + "...")
@@ -53,9 +54,8 @@ func buildHandler() http.Handler {
 	}
 
 	// CORS Headers
-	// https://stackoverflow.com/questions/40985920/making-golang-gorilla-cors-handler-work
 	headersOk := handlers.AllowedHeaders([]string{"X-Requested-With"})
-	originsOk := handlers.AllowedOrigins([]string{"*"})
+	originsOk := handlers.AllowedOriginValidator(isCORSOriginAllowed)
 	methodsOk := handlers.AllowedMethods([]string{"GET", "HEAD", "POST", "PUT", "OPTIONS"})
 
 	apiRouter.HandleFunc("/docker/services", dockerServicesHandler)

--- a/server-src/origin_policy.go
+++ b/server-src/origin_policy.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+)
+
+const allowedOriginsEnv = "DSD_ALLOWED_ORIGINS"
+
+func warnIfAllowedOriginsUnset() {
+	if os.Getenv(allowedOriginsEnv) == "" {
+		log.Printf("WARNING: %s is not set; allowing all HTTP CORS and WebSocket origins for backward compatibility", allowedOriginsEnv)
+	}
+}
+
+func getAllowedOrigins() []string {
+	value := os.Getenv(allowedOriginsEnv)
+	if value == "" {
+		return []string{"*"}
+	}
+
+	parts := strings.Split(value, ",")
+	origins := make([]string, 0, len(parts))
+	for _, part := range parts {
+		origin := strings.TrimSpace(part)
+		if origin != "" {
+			origins = append(origins, origin)
+		}
+	}
+	return origins
+}
+
+func isOriginInAllowedList(origin string) bool {
+	for _, allowedOrigin := range getAllowedOrigins() {
+		if allowedOrigin == "*" || allowedOrigin == origin {
+			return true
+		}
+	}
+	return false
+}
+
+func isCORSOriginAllowed(origin string) bool {
+	if origin == "" {
+		return false
+	}
+	return isOriginInAllowedList(origin)
+}
+
+func isWebSocketOriginAllowed(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return true
+	}
+	return isOriginInAllowedList(origin)
+}
+
+func isWebSocketSameOriginAllowed(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return true
+	}
+	originURL, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(originURL.Host, r.Host)
+}

--- a/server-src/origin_policy.go
+++ b/server-src/origin_policy.go
@@ -3,7 +3,6 @@ package main
 import (
 	"log"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 )
@@ -55,16 +54,4 @@ func isWebSocketOriginAllowed(r *http.Request) bool {
 		return true
 	}
 	return isOriginInAllowedList(origin)
-}
-
-func isWebSocketSameOriginAllowed(r *http.Request) bool {
-	origin := r.Header.Get("Origin")
-	if origin == "" {
-		return true
-	}
-	originURL, err := url.Parse(origin)
-	if err != nil {
-		return false
-	}
-	return strings.EqualFold(originURL.Host, r.Host)
 }

--- a/server-src/origin_policy_test.go
+++ b/server-src/origin_policy_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIsCORSOriginAllowed(t *testing.T) {
+	t.Setenv(allowedOriginsEnv, "https://dashboard.example.com, https://admin.example.com")
+
+	if !isCORSOriginAllowed("https://dashboard.example.com") {
+		t.Fatal("expected configured CORS origin to be allowed")
+	}
+	if isCORSOriginAllowed("https://evil.example.com") {
+		t.Fatal("expected unconfigured CORS origin to be rejected")
+	}
+}
+
+func TestIsCORSOriginAllowedWildcard(t *testing.T) {
+	t.Setenv(allowedOriginsEnv, "*")
+
+	if !isCORSOriginAllowed("https://any.example.com") {
+		t.Fatal("expected wildcard CORS origin to be allowed")
+	}
+}
+
+func TestIsWebSocketOriginAllowedDefaultAllowsAllOrigins(t *testing.T) {
+	t.Setenv(allowedOriginsEnv, "")
+
+	req := httptest.NewRequest(http.MethodGet, "http://dashboard.local/docker/logs/svc", nil)
+	req.Header.Set("Origin", "http://dashboard.local")
+	if !isWebSocketOriginAllowed(req) {
+		t.Fatal("expected same-origin websocket request to be allowed by default")
+	}
+
+	req.Header.Set("Origin", "https://evil.example.com")
+	if !isWebSocketOriginAllowed(req) {
+		t.Fatal("expected cross-origin websocket request to remain allowed by default")
+	}
+}
+
+func TestIsWebSocketOriginAllowedConfiguredOrigin(t *testing.T) {
+	t.Setenv(allowedOriginsEnv, "https://dashboard.example.com")
+
+	req := httptest.NewRequest(http.MethodGet, "http://dashboard.local/docker/logs/svc", nil)
+	req.Header.Set("Origin", "https://dashboard.example.com")
+	if !isWebSocketOriginAllowed(req) {
+		t.Fatal("expected configured websocket origin to be allowed")
+	}
+
+	req.Header.Set("Origin", "http://dashboard.local")
+	if isWebSocketOriginAllowed(req) {
+		t.Fatal("expected unconfigured websocket origin to be rejected when allow-list is set")
+	}
+}
+
+func TestBuildHandlerCORSAllowedOrigin(t *testing.T) {
+	t.Setenv(allowedOriginsEnv, "https://dashboard.example.com")
+
+	req := httptest.NewRequest(http.MethodOptions, "/health", nil)
+	req.Header.Set("Origin", "https://dashboard.example.com")
+	req.Header.Set("Access-Control-Request-Method", http.MethodGet)
+	w := httptest.NewRecorder()
+
+	buildHandler().ServeHTTP(w, req)
+
+	if got := w.Result().Header.Get("Access-Control-Allow-Origin"); got != "https://dashboard.example.com" {
+		t.Fatalf("expected configured CORS origin header, got %q", got)
+	}
+}
+
+func TestBuildHandlerCORSDefaultAllowsAllOrigins(t *testing.T) {
+	t.Setenv(allowedOriginsEnv, "")
+
+	req := httptest.NewRequest(http.MethodOptions, "/health", nil)
+	req.Header.Set("Origin", "https://any.example.com")
+	req.Header.Set("Access-Control-Request-Method", http.MethodGet)
+	w := httptest.NewRecorder()
+
+	buildHandler().ServeHTTP(w, req)
+
+	if got := w.Result().Header.Get("Access-Control-Allow-Origin"); got != "https://any.example.com" {
+		t.Fatalf("expected default CORS origin header to allow request origin, got %q", got)
+	}
+}
+
+func TestBuildHandlerCORSDeniedOrigin(t *testing.T) {
+	t.Setenv(allowedOriginsEnv, "https://dashboard.example.com")
+
+	req := httptest.NewRequest(http.MethodOptions, "/health", nil)
+	req.Header.Set("Origin", "https://evil.example.com")
+	req.Header.Set("Access-Control-Request-Method", http.MethodGet)
+	w := httptest.NewRecorder()
+
+	buildHandler().ServeHTTP(w, req)
+
+	if got := w.Result().Header.Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("expected no CORS origin header for denied origin, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `DSD_ALLOWED_ORIGINS` for shared HTTP CORS and WebSocket origin validation.
- Preserve the historical allow-all default for backward compatibility and log a startup warning when the variable is unset.
- Document the new setting and add tests for allowed, denied, wildcard, and default-origin behavior.

## Verification
- `go test ./...`
- Local server test with `DSD_ALLOWED_ORIGINS=https://dashboard.example.com`: allowed CORS/WebSocket origins accepted, unconfigured origins rejected.
- Local server test without `DSD_ALLOWED_ORIGINS`: CORS/WebSocket allow-all behavior preserved and startup warning logged.

Closes #1079
Closes #1080