### PR TITLE
feat: mask secrets in the container specs served by the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Docker Swarm Dashboard supports environment variables for configuration.
 | `DSD_HIDE_SERVICE_STATES` | Comma-separated list of states to not show in the main dashboard. | (none) |
 | `DSD_PATH_PREFIX` | Set a URL path prefix for the dashboard (e.g. `/dashboard`). Useful when running behind a reverse proxy or when the app should not be served from the root path. | `/` |
 | `DSD_ALLOWED_ORIGINS` | Comma-separated list of allowed HTTP CORS and WebSocket origins (e.g. `https://dashboard.example.com`). The default keeps the historical behavior and allows all origins. Set a concrete allow-list to restrict browser access. | `*` |
+| `DSD_MASK_ENV` | Masks the secrets of the container specs served by the services, tasks and nodes endpoints: environment variable values, command-line arguments, labels and credential specs. Names and flags stay visible, values are replaced by a fixed-length placeholder. Set to `false` to expose the raw values. | `true` |
 | `DSD_NODE_EXPORTER_LABEL` | Docker service label to identify node-exporter service for metrics collection. | `dsd.node-exporter` |
 | `DSD_CADVISOR_LABEL` | Docker service label to identify cAdvisor service for container memory metrics. | `dsd.cadvisor` |
 | `LOCALE` | Timestamp format based on a [BCP 47](https://www.rfc-editor.org/bcp/bcp47.txt) language tag. | (system) |

--- a/server-src/docker_nodes_details_handler.go
+++ b/server-src/docker_nodes_details_handler.go
@@ -45,7 +45,7 @@ func dockerNodesDetailsHandler(w http.ResponseWriter, r *http.Request) {
 
 		// Enrich tasks with Service object when possible to match mock shape
 		enriched := make([]map[string]interface{}, 0, len(Tasks))
-		for _, t := range Tasks {
+		for _, t := range maskTasksEnv(Tasks) {
 			var tm map[string]interface{}
 			b, _ := json.Marshal(t)
 			_ = json.Unmarshal(b, &tm)
@@ -54,7 +54,7 @@ func dockerNodesDetailsHandler(w http.ResponseWriter, r *http.Request) {
 			servicesFilter.Add("id", t.ServiceID)
 			svcList, _ := cli.ServiceList(context.Background(), swarm.ServiceListOptions{Filters: servicesFilter})
 			if len(svcList) > 0 {
-				tm["Service"] = svcList[0]
+				tm["Service"] = maskServiceEnv(svcList[0])
 			} else {
 				tm["Service"] = nil
 			}

--- a/server-src/docker_services_details_handler.go
+++ b/server-src/docker_services_details_handler.go
@@ -45,7 +45,7 @@ func dockerServicesDetailsHandler(w http.ResponseWriter, r *http.Request) {
 
 		// Attach Node object to each task when possible to match mock shape
 		enriched := make([]map[string]interface{}, 0, len(Tasks))
-		for _, t := range Tasks {
+		for _, t := range maskTasksEnv(Tasks) {
 			// convert task to a generic map first
 			var tm map[string]interface{}
 			b, _ := json.Marshal(t)
@@ -65,7 +65,7 @@ func dockerServicesDetailsHandler(w http.ResponseWriter, r *http.Request) {
 
 		// Return the same shape as the mock server: { service, tasks }
 		resp := map[string]interface{}{
-			"service": Services[0],
+			"service": maskServiceEnv(Services[0]),
 			"tasks":   enriched,
 		}
 		jsonString, _ := json.Marshal(resp)

--- a/server-src/docker_services_handler.go
+++ b/server-src/docker_services_handler.go
@@ -21,7 +21,7 @@ func dockerServicesHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(Services); err != nil {
+	if err := json.NewEncoder(w).Encode(maskServicesEnv(Services)); err != nil {
 		log.Printf("dockerServicesHandler: encoding response failed: %v", err)
 	}
 }

--- a/server-src/docker_tasks_details_handler.go
+++ b/server-src/docker_tasks_details_handler.go
@@ -27,7 +27,7 @@ func dockerTasksDetailsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if len(Tasks) == 1 {
-		t := Tasks[0]
+		t := maskTaskEnv(Tasks[0])
 		// convert task to a generic map first
 		var tm map[string]interface{}
 		b, _ := json.Marshal(t)

--- a/server-src/docker_tasks_handler.go
+++ b/server-src/docker_tasks_handler.go
@@ -21,7 +21,7 @@ func dockerTasksHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(Tasks); err != nil {
+	if err := json.NewEncoder(w).Encode(maskTasksEnv(Tasks)); err != nil {
 		log.Printf("dockerTasksHandler: encoding response failed: %v", err)
 	}
 }

--- a/server-src/env_masking.go
+++ b/server-src/env_masking.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/docker/docker/api/types/swarm"
+	masker "github.com/ggwhite/go-masker/v3"
+)
+
+const maskEnvEnv = "DSD_MASK_ENV"
+
+// isEnvMaskingEnabled reports whether the secret-bearing fields of a container
+// spec must be masked before being serialized. Masking is on by default; set
+// DSD_MASK_ENV to a false value to expose the raw values.
+func isEnvMaskingEnabled() bool {
+	value := os.Getenv(maskEnvEnv)
+	if value == "" {
+		return true
+	}
+	enabled, err := strconv.ParseBool(value)
+	if err != nil {
+		return true
+	}
+	return enabled
+}
+
+// maskEnvEntry masks the value of a single "KEY=value" entry. The key is kept
+// visible so operators can still tell which variables a service defines, and
+// the replacement has a fixed length so it does not leak the value's size.
+func maskEnvEntry(entry string) string {
+	key, value, found := strings.Cut(entry, "=")
+	if !found || value == "" {
+		return entry
+	}
+	return key + "=" + masker.Password(value)
+}
+
+func maskEnvSlice(env []string) []string {
+	if len(env) == 0 {
+		return env
+	}
+	masked := make([]string, len(env))
+	for i, entry := range env {
+		masked[i] = maskEnvEntry(entry)
+	}
+	return masked
+}
+
+// sensitiveArgName matches the argument names that are usually followed by a
+// secret held in a separate token, such as "--password s3cr3t".
+var sensitiveArgName = regexp.MustCompile(`(?i)pass|pwd|secret|token|key|cred|auth`)
+
+// structuralLabelPrefixes lists the label namespaces holding structural metadata
+// — stack membership, image provenance, dashboard service discovery — rather
+// than user data. Their values stay readable; everything else is masked.
+var structuralLabelPrefixes = []string{"com.docker.", "org.opencontainers.", "dsd."}
+
+// maskArgs masks the secrets carried by a command line. Three shapes are
+// covered: a value glued to its flag ("--password=s3cr3t"), a value held in the
+// token following a sensitive flag ("--password s3cr3t"), and credentials
+// embedded in a URL ("postgres://user:pw@host"). Flag names and plain tokens
+// stay readable so the command line remains recognisable.
+func maskArgs(args []string) []string {
+	if len(args) == 0 {
+		return args
+	}
+	masked := make([]string, len(args))
+	maskNextToken := false
+	for i, arg := range args {
+		isFlag := strings.HasPrefix(arg, "-")
+		switch {
+		case maskNextToken && !isFlag:
+			masked[i] = masker.Password(arg)
+		case strings.Contains(arg, "="):
+			masked[i] = maskEnvEntry(arg)
+		default:
+			masked[i] = masker.URL(arg)
+		}
+		maskNextToken = isFlag && !strings.Contains(arg, "=") && sensitiveArgName.MatchString(arg)
+	}
+	return masked
+}
+
+func maskLabels(labels map[string]string) map[string]string {
+	if len(labels) == 0 {
+		return labels
+	}
+	masked := make(map[string]string, len(labels))
+	for key, value := range labels {
+		if value == "" || hasStructuralPrefix(key) {
+			masked[key] = value
+			continue
+		}
+		masked[key] = masker.Password(value)
+	}
+	return masked
+}
+
+func hasStructuralPrefix(label string) bool {
+	for _, prefix := range structuralLabelPrefixes {
+		if strings.HasPrefix(label, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// maskCredentialSpec masks the managed service account references. They name a
+// config, a file or a registry key holding Windows credentials, so they point at
+// secrets even when they are not secrets themselves.
+func maskCredentialSpec(spec *swarm.CredentialSpec) *swarm.CredentialSpec {
+	masked := *spec
+	masked.Config = maskIfSet(masked.Config)
+	masked.File = maskIfSet(masked.File)
+	masked.Registry = maskIfSet(masked.Registry)
+	return &masked
+}
+
+func maskIfSet(value string) string {
+	if value == "" {
+		return value
+	}
+	return masker.Password(value)
+}
+
+// maskTaskSpecEnv masks every secret-bearing field of a task spec. The
+// ContainerSpec is copied before being rewritten, so the spec the caller
+// received from the Docker API keeps its original values.
+func maskTaskSpecEnv(spec *swarm.TaskSpec) {
+	if spec == nil || spec.ContainerSpec == nil {
+		return
+	}
+	containerSpec := *spec.ContainerSpec
+	containerSpec.Env = maskEnvSlice(containerSpec.Env)
+	containerSpec.Command = maskArgs(containerSpec.Command)
+	containerSpec.Args = maskArgs(containerSpec.Args)
+	containerSpec.Labels = maskLabels(containerSpec.Labels)
+	if containerSpec.Privileges != nil && containerSpec.Privileges.CredentialSpec != nil {
+		privileges := *containerSpec.Privileges
+		privileges.CredentialSpec = maskCredentialSpec(privileges.CredentialSpec)
+		containerSpec.Privileges = &privileges
+	}
+	spec.ContainerSpec = &containerSpec
+}
+
+// maskServiceSpecEnv masks the service-level labels and the container spec of a
+// service spec. The service name is left alone, the UI identifies services by it.
+func maskServiceSpecEnv(spec *swarm.ServiceSpec) {
+	spec.Labels = maskLabels(spec.Labels)
+	maskTaskSpecEnv(&spec.TaskTemplate)
+}
+
+// maskServiceEnv returns a copy of the service with the secrets of both its
+// current and its previous spec masked.
+func maskServiceEnv(service swarm.Service) swarm.Service {
+	if !isEnvMaskingEnabled() {
+		return service
+	}
+	maskServiceSpecEnv(&service.Spec)
+	if service.PreviousSpec != nil {
+		previousSpec := *service.PreviousSpec
+		maskServiceSpecEnv(&previousSpec)
+		service.PreviousSpec = &previousSpec
+	}
+	return service
+}
+
+func maskServicesEnv(services []swarm.Service) []swarm.Service {
+	if !isEnvMaskingEnabled() || len(services) == 0 {
+		return services
+	}
+	masked := make([]swarm.Service, len(services))
+	for i, service := range services {
+		masked[i] = maskServiceEnv(service)
+	}
+	return masked
+}
+
+// maskTaskEnv returns a copy of the task with its labels and the secrets of its
+// spec masked.
+func maskTaskEnv(task swarm.Task) swarm.Task {
+	if !isEnvMaskingEnabled() {
+		return task
+	}
+	task.Labels = maskLabels(task.Labels)
+	maskTaskSpecEnv(&task.Spec)
+	return task
+}
+
+func maskTasksEnv(tasks []swarm.Task) []swarm.Task {
+	if !isEnvMaskingEnabled() || len(tasks) == 0 {
+		return tasks
+	}
+	masked := make([]swarm.Task, len(tasks))
+	for i, task := range tasks {
+		masked[i] = maskTaskEnv(task)
+	}
+	return masked
+}

--- a/server-src/env_masking_test.go
+++ b/server-src/env_masking_test.go
@@ -1,0 +1,376 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	swarmtypes "github.com/docker/docker/api/types/swarm"
+)
+
+const maskedValue = "**************"
+
+func containerSpecWithEnv(env ...string) *swarmtypes.ContainerSpec {
+	return &swarmtypes.ContainerSpec{Image: "alpine", Env: env}
+}
+
+func TestMaskEnvEntry(t *testing.T) {
+	cases := []struct {
+		name     string
+		entry    string
+		expected string
+	}{
+		{"masks the value", "POSTGRES_PASSWORD=s3cr3t", "POSTGRES_PASSWORD=" + maskedValue},
+		{"masks everything after the first separator", "URL=postgres://user:pw@host/db", "URL=" + maskedValue},
+		{"keeps an empty value untouched", "EMPTY=", "EMPTY="},
+		{"keeps an entry without separator untouched", "JUST_A_KEY", "JUST_A_KEY"},
+		{"keeps an empty entry untouched", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := maskEnvEntry(tc.entry); got != tc.expected {
+				t.Fatalf("expected %q got %q", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestMaskServiceEnvMasksCurrentAndPreviousSpec(t *testing.T) {
+	service := swarmtypes.Service{
+		ID: "s1",
+		Spec: swarmtypes.ServiceSpec{
+			TaskTemplate: swarmtypes.TaskSpec{ContainerSpec: containerSpecWithEnv("API_TOKEN=current-secret")},
+		},
+		PreviousSpec: &swarmtypes.ServiceSpec{
+			TaskTemplate: swarmtypes.TaskSpec{ContainerSpec: containerSpecWithEnv("API_TOKEN=previous-secret")},
+		},
+	}
+
+	masked := maskServiceEnv(service)
+
+	if got := masked.Spec.TaskTemplate.ContainerSpec.Env[0]; got != "API_TOKEN="+maskedValue {
+		t.Fatalf("current spec not masked, got %q", got)
+	}
+	if got := masked.PreviousSpec.TaskTemplate.ContainerSpec.Env[0]; got != "API_TOKEN="+maskedValue {
+		t.Fatalf("previous spec not masked, got %q", got)
+	}
+	if got := service.Spec.TaskTemplate.ContainerSpec.Env[0]; got != "API_TOKEN=current-secret" {
+		t.Fatalf("original service was mutated, got %q", got)
+	}
+	if got := service.PreviousSpec.TaskTemplate.ContainerSpec.Env[0]; got != "API_TOKEN=previous-secret" {
+		t.Fatalf("original previous spec was mutated, got %q", got)
+	}
+	if masked.Spec.TaskTemplate.ContainerSpec.Image != "alpine" {
+		t.Fatal("the rest of the container spec must be preserved")
+	}
+}
+
+func TestMaskServiceEnvWithoutContainerSpec(t *testing.T) {
+	service := swarmtypes.Service{ID: "s1"}
+	if masked := maskServiceEnv(service); masked.Spec.TaskTemplate.ContainerSpec != nil {
+		t.Fatal("expected a nil container spec to stay nil")
+	}
+}
+
+func TestMaskTaskEnv(t *testing.T) {
+	task := swarmtypes.Task{
+		ID:   "t1",
+		Spec: swarmtypes.TaskSpec{ContainerSpec: containerSpecWithEnv("DB_PASSWORD=hunter2", "LOG_LEVEL=debug")},
+	}
+
+	masked := maskTaskEnv(task)
+
+	expected := []string{"DB_PASSWORD=" + maskedValue, "LOG_LEVEL=" + maskedValue}
+	for i, want := range expected {
+		if got := masked.Spec.ContainerSpec.Env[i]; got != want {
+			t.Fatalf("expected %q got %q", want, got)
+		}
+	}
+	if got := task.Spec.ContainerSpec.Env[0]; got != "DB_PASSWORD=hunter2" {
+		t.Fatalf("original task was mutated, got %q", got)
+	}
+}
+
+func TestMaskArgs(t *testing.T) {
+	cases := []struct {
+		name     string
+		args     []string
+		expected []string
+	}{
+		{
+			"masks a value glued to its flag",
+			[]string{"serve", "--password=s3cr3t"},
+			[]string{"serve", "--password=" + maskedValue},
+		},
+		{
+			"masks the token following a sensitive flag",
+			[]string{"--password", "s3cr3t", "--verbose"},
+			[]string{"--password", maskedValue, "--verbose"},
+		},
+		{
+			"keeps the token following an ordinary flag",
+			[]string{"--log-level", "debug"},
+			[]string{"--log-level", "debug"},
+		},
+		{
+			"does not swallow the flag following a sensitive flag",
+			[]string{"--token", "--verbose"},
+			[]string{"--token", "--verbose"},
+		},
+		{
+			"masks credentials embedded in a URL",
+			[]string{"postgres://user:pw@host/db"},
+			[]string{"postgres://user:xxxxx@host/db"},
+		},
+		{
+			"keeps a plain command readable",
+			[]string{"/bin/sh", "-c", "start"},
+			[]string{"/bin/sh", "-c", "start"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := maskArgs(tc.args)
+			if len(got) != len(tc.expected) {
+				t.Fatalf("expected %v got %v", tc.expected, got)
+			}
+			for i := range got {
+				if got[i] != tc.expected[i] {
+					t.Fatalf("expected %v got %v", tc.expected, got)
+				}
+			}
+		})
+	}
+}
+
+func TestMaskLabels(t *testing.T) {
+	labels := map[string]string{
+		"com.docker.stack.namespace":      "my-stack",
+		"org.opencontainers.image.source": "https://example.com/repo",
+		"dsd.node-exporter":               "true",
+		"internal.api-key":                "s3cr3t",
+		"empty":                           "",
+	}
+
+	masked := maskLabels(labels)
+
+	for _, key := range []string{"com.docker.stack.namespace", "org.opencontainers.image.source", "dsd.node-exporter", "empty"} {
+		if masked[key] != labels[key] {
+			t.Fatalf("structural label %q must stay readable, got %q", key, masked[key])
+		}
+	}
+	if masked["internal.api-key"] != maskedValue {
+		t.Fatalf("expected a masked label value, got %q", masked["internal.api-key"])
+	}
+	if labels["internal.api-key"] != "s3cr3t" {
+		t.Fatal("the original label map was mutated")
+	}
+}
+
+func TestMaskContainerSpecSecrets(t *testing.T) {
+	spec := swarmtypes.TaskSpec{ContainerSpec: &swarmtypes.ContainerSpec{
+		Image:   "alpine",
+		Command: []string{"/entrypoint.sh", "--api-token=s3cr3t"},
+		Args:    []string{"--password", "hunter2"},
+		Labels:  map[string]string{"internal.api-key": "leaked"},
+		Privileges: &swarmtypes.Privileges{
+			CredentialSpec: &swarmtypes.CredentialSpec{Config: "cfg", File: "spec.json", Registry: ""},
+		},
+	}}
+
+	maskTaskSpecEnv(&spec)
+
+	if got := spec.ContainerSpec.Command[1]; got != "--api-token="+maskedValue {
+		t.Fatalf("command not masked, got %q", got)
+	}
+	if got := spec.ContainerSpec.Args[1]; got != maskedValue {
+		t.Fatalf("args not masked, got %q", got)
+	}
+	if got := spec.ContainerSpec.Labels["internal.api-key"]; got != maskedValue {
+		t.Fatalf("labels not masked, got %q", got)
+	}
+	credentialSpec := spec.ContainerSpec.Privileges.CredentialSpec
+	if credentialSpec.Config != maskedValue || credentialSpec.File != maskedValue {
+		t.Fatalf("credential spec not masked, got %+v", credentialSpec)
+	}
+	if credentialSpec.Registry != "" {
+		t.Fatalf("an empty credential field must stay empty, got %q", credentialSpec.Registry)
+	}
+	if spec.ContainerSpec.Image != "alpine" {
+		t.Fatal("the rest of the container spec must be preserved")
+	}
+}
+
+func TestMaskContainerSpecDoesNotMutateSource(t *testing.T) {
+	privileges := &swarmtypes.Privileges{CredentialSpec: &swarmtypes.CredentialSpec{Config: "cfg"}}
+	containerSpec := &swarmtypes.ContainerSpec{
+		Args:       []string{"--password", "hunter2"},
+		Labels:     map[string]string{"internal.api-key": "leaked"},
+		Privileges: privileges,
+	}
+	spec := swarmtypes.TaskSpec{ContainerSpec: containerSpec}
+
+	maskTaskSpecEnv(&spec)
+
+	if containerSpec.Args[1] != "hunter2" {
+		t.Fatalf("original args were mutated, got %q", containerSpec.Args[1])
+	}
+	if containerSpec.Labels["internal.api-key"] != "leaked" {
+		t.Fatal("original labels were mutated")
+	}
+	if privileges.CredentialSpec.Config != "cfg" {
+		t.Fatalf("original credential spec was mutated, got %q", privileges.CredentialSpec.Config)
+	}
+}
+
+func TestMaskServiceLabels(t *testing.T) {
+	service := swarmtypes.Service{
+		Spec: swarmtypes.ServiceSpec{
+			Annotations: swarmtypes.Annotations{
+				Name:   "my-service",
+				Labels: map[string]string{"com.docker.stack.namespace": "my-stack", "internal.api-key": "s3cr3t"},
+			},
+		},
+		PreviousSpec: &swarmtypes.ServiceSpec{
+			Annotations: swarmtypes.Annotations{Labels: map[string]string{"internal.api-key": "previous-secret"}},
+		},
+	}
+
+	masked := maskServiceEnv(service)
+
+	if masked.Spec.Name != "my-service" {
+		t.Fatalf("the service name must stay readable, got %q", masked.Spec.Name)
+	}
+	if got := masked.Spec.Labels["com.docker.stack.namespace"]; got != "my-stack" {
+		t.Fatalf("stack grouping must survive masking, got %q", got)
+	}
+	if got := masked.Spec.Labels["internal.api-key"]; got != maskedValue {
+		t.Fatalf("service label not masked, got %q", got)
+	}
+	if got := masked.PreviousSpec.Labels["internal.api-key"]; got != maskedValue {
+		t.Fatalf("previous spec label not masked, got %q", got)
+	}
+	if service.Spec.Labels["internal.api-key"] != "s3cr3t" {
+		t.Fatal("the original service labels were mutated")
+	}
+}
+
+func TestMaskTaskLabels(t *testing.T) {
+	task := swarmtypes.Task{
+		ID:          "t1",
+		Annotations: swarmtypes.Annotations{Labels: map[string]string{"internal.api-key": "s3cr3t"}},
+	}
+
+	masked := maskTaskEnv(task)
+
+	if got := masked.Labels["internal.api-key"]; got != maskedValue {
+		t.Fatalf("task label not masked, got %q", got)
+	}
+	if task.Labels["internal.api-key"] != "s3cr3t" {
+		t.Fatal("the original task labels were mutated")
+	}
+}
+
+func TestMaskEnvSlicesPreserveNil(t *testing.T) {
+	if maskServicesEnv(nil) != nil {
+		t.Fatal("expected a nil service slice to stay nil")
+	}
+	if maskTasksEnv(nil) != nil {
+		t.Fatal("expected a nil task slice to stay nil")
+	}
+}
+
+func TestEnvMaskingCanBeDisabled(t *testing.T) {
+	t.Setenv(maskEnvEnv, "false")
+
+	task := swarmtypes.Task{Spec: swarmtypes.TaskSpec{ContainerSpec: containerSpecWithEnv("DB_PASSWORD=hunter2")}}
+	if got := maskTaskEnv(task).Spec.ContainerSpec.Env[0]; got != "DB_PASSWORD=hunter2" {
+		t.Fatalf("expected the raw value when masking is disabled, got %q", got)
+	}
+}
+
+func TestEnvMaskingEnabledByDefault(t *testing.T) {
+	cases := map[string]bool{"": true, "true": true, "1": true, "false": false, "0": false, "not-a-bool": true}
+	for value, expected := range cases {
+		t.Run("DSD_MASK_ENV="+value, func(t *testing.T) {
+			t.Setenv(maskEnvEnv, value)
+			if got := isEnvMaskingEnabled(); got != expected {
+				t.Fatalf("expected %v got %v", expected, got)
+			}
+		})
+	}
+}
+
+// TestDockerServicesHandlerMasksEnv verifies that no raw environment value ever
+// reaches the HTTP response of the services endpoint.
+func TestDockerServicesHandlerMasksEnv(t *testing.T) {
+	services := []swarmtypes.Service{{
+		ID: "s1",
+		Spec: swarmtypes.ServiceSpec{
+			Annotations:  swarmtypes.Annotations{Name: "svc1"},
+			TaskTemplate: swarmtypes.TaskSpec{ContainerSpec: containerSpecWithEnv("POSTGRES_PASSWORD=s3cr3t")},
+		},
+	}}
+	b, _ := json.Marshal(services)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/v1.35/services") {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(b)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	defer ResetCli()
+	SetCli(makeClientForServer(t, server.URL))
+
+	req := httptest.NewRequest(http.MethodGet, "/docker/services", nil)
+	w := httptest.NewRecorder()
+	dockerServicesHandler(w, req)
+
+	body := w.Body.String()
+	if strings.Contains(body, "s3cr3t") {
+		t.Fatalf("the response leaks the raw environment value: %s", body)
+	}
+	if !strings.Contains(body, "POSTGRES_PASSWORD="+maskedValue) {
+		t.Fatalf("expected a masked environment entry, got %s", body)
+	}
+}
+
+// TestDockerTasksHandlerMasksEnv verifies the same for the tasks endpoint.
+func TestDockerTasksHandlerMasksEnv(t *testing.T) {
+	tasks := []swarmtypes.Task{{
+		ID:   "t1",
+		Spec: swarmtypes.TaskSpec{ContainerSpec: containerSpecWithEnv("DB_PASSWORD=hunter2")},
+	}}
+	b, _ := json.Marshal(tasks)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/v1.35/tasks") {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(b)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	defer ResetCli()
+	SetCli(makeClientForServer(t, server.URL))
+
+	req := httptest.NewRequest(http.MethodGet, "/docker/tasks", nil)
+	w := httptest.NewRecorder()
+	dockerTasksHandler(w, req)
+
+	body := w.Body.String()
+	if strings.Contains(body, "hunter2") {
+		t.Fatalf("the response leaks the raw environment value: %s", body)
+	}
+	if !strings.Contains(body, "DB_PASSWORD="+maskedValue) {
+		t.Fatalf("expected a masked environment entry, got %s", body)
+	}
+}

--- a/server-src/go.mod
+++ b/server-src/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/docker/docker v28.5.2+incompatible
+	github.com/ggwhite/go-masker/v3 v3.3.0
 	github.com/gorilla/handlers v1.5.2
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.3

--- a/server-src/go.sum
+++ b/server-src/go.sum
@@ -27,6 +27,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/ggwhite/go-masker/v3 v3.3.0 h1:TGAoxfDMbwbWqzlWZs8ftXFbUY72ViM+XZNXMh8suz8=
+github.com/ggwhite/go-masker/v3 v3.3.0/go.mod h1:ytCQqKDopvdVynup9RhOT0+uaTxbaQl+QW7P27HLDfs=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=


### PR DESCRIPTION
The services, tasks and nodes endpoints serialized the raw swarm specs, so the whole container spec reached any client able to open the dashboard: environment variables, command line, labels and credential specs. Database passwords, API tokens and connection strings routinely live there.

Secrets are now replaced by a fixed-length placeholder before serialization, using github.com/ggwhite/go-masker. What stays readable is what identifies rather than what authenticates:

  - environment variables keep their names, values are masked
  - Command and Args keep their flags and plain tokens; a value glued to its flag, the token following a sensitive flag name, and credentials embedded in a URL are masked
  - labels are masked except under com.docker., org.opencontainers. and dsd., which carry stack membership, image provenance and dashboard service discovery rather than user data
  - Privileges.CredentialSpec is masked entirely, each of its fields points at Windows credentials
  - service and task names are left alone, the UI identifies objects by them

Masking covers the service labels and container spec of both the current and the previous service spec, and the labels and spec of a task. The placeholder has a constant length so it does not leak the size of a secret, and the ContainerSpec is copied before being rewritten so the object returned by the Docker SDK is left untouched. Set DSD_MASK_ENV=false to expose the raw values; an unparsable value falls back to masking.