### PR TITLE
Fix: logs streaming and filter focus

### DIFF
--- a/app-src/cypress/e2e/ui-interactions/filter_focus.cy.js
+++ b/app-src/cypress/e2e/ui-interactions/filter_focus.cy.js
@@ -1,0 +1,41 @@
+describe('Filter input keyboard focus', () => {
+  it('keeps focus and the typed value while typing in the dashboard filter', () => {
+    cy.get('a[aria-label="Dashboard"]').click()
+    cy.get('#dashboardTable', { timeout: 10000 }).should('exist')
+
+    cy.get('input[aria-label="Filter by service name"]').as('filter')
+    cy.get('@filter').click().type('front')
+
+    // The filter atom used to suspend on every keystroke, which unmounted the
+    // whole view and moved focus back to the document body after one letter.
+    cy.get('@filter').should('have.value', 'front')
+    cy.focused().should('have.attr', 'aria-label', 'Filter by service name')
+    cy.get('#dashboardTable').should('exist')
+  })
+
+  it('keeps focus while typing in the stacks filter', () => {
+    cy.get('a[aria-label="Stacks"]').click()
+    cy.get('input[aria-label="Filter by service name"]', { timeout: 10000 })
+      .as('filter')
+      .click()
+      .type('front')
+
+    cy.get('@filter').should('have.value', 'front')
+    cy.focused().should('have.attr', 'aria-label', 'Filter by service name')
+  })
+
+  it('does not push a history entry per keystroke', () => {
+    cy.get('a[aria-label="Dashboard"]').click()
+    cy.get('#dashboardTable', { timeout: 10000 }).should('exist')
+
+    cy.window().then((win) => {
+      const before = win.history.length
+      cy.get('input[aria-label="Filter by service name"]').click().type('front')
+      cy.get('input[aria-label="Filter by service name"]').should(
+        'have.value',
+        'front',
+      )
+      cy.window().its('history.length').should('eq', before)
+    })
+  })
+})

--- a/app-src/src/common/store/atoms/dashboardAtoms.js
+++ b/app-src/src/common/store/atoms/dashboardAtoms.js
@@ -1,6 +1,6 @@
 import { atom } from 'jotai'
 import { atomFamily } from 'jotai-family'
-import { baseUrlAtom } from './foundationAtoms'
+import { baseUrlAtom, mapMaybePromise } from './foundationAtoms'
 import { viewAtom } from './navigationAtoms'
 import { defaultLayoutAtom } from './uiAtoms'
 import { dashboardHId, dashboardVId } from '../../navigationConstants'
@@ -141,7 +141,8 @@ export const versionAtom = atom(async (get) => {
  * Dashboard settings default layout view ID: determines whether horizontal or vertical
  * dashboard should be shown by default based on the user's saved layout preference.
  */
-export const dashboardSettingsDefaultLayoutViewIdAtom = atom(async (get) => {
-  const defaultLayout = await get(defaultLayoutAtom)
-  return defaultLayout === 'row' ? dashboardHId : dashboardVId
-})
+export const dashboardSettingsDefaultLayoutViewIdAtom = atom((get) =>
+  mapMaybePromise(get(defaultLayoutAtom), (defaultLayout) =>
+    defaultLayout === 'row' ? dashboardHId : dashboardVId,
+  ),
+)

--- a/app-src/src/common/store/atoms/foundationAtoms.js
+++ b/app-src/src/common/store/atoms/foundationAtoms.js
@@ -2,23 +2,48 @@ import { atom } from 'jotai'
 import { atomWithHash } from 'jotai-location'
 
 /**
+ * Applies `fn` to `value`, keeping the result synchronous when `value` is not
+ * a promise.
+ *
+ * Derived atoms must not be declared `async` when their sources can resolve
+ * synchronously: an async read function always returns a *new* pending
+ * promise, which makes every consuming component suspend again on each
+ * update. Under a `<Suspense>` boundary that unmounts the whole subtree,
+ * losing DOM state such as input focus.
+ *
+ * @param {any} value - A plain value or a promise
+ * @param {Function} fn - Mapping function applied to the resolved value
+ * @returns {any} The mapped value, or a promise of it when `value` is a promise
+ */
+export const mapMaybePromise = (value, fn) =>
+  value instanceof Promise ? value.then(fn) : fn(value)
+
+/**
  * Creates an atom that:
  * 1. Reads from URL hash first (if value exists)
  * 2. Falls back to server default if no hash value
  * 3. Writes changes back to URL hash
+ *
+ * The read function is intentionally synchronous: once a value is present in
+ * the URL hash the atom resolves without suspending, so typing in a
+ * hash-backed input does not remount the view. Only the initial read (before
+ * the server defaults have arrived) returns the pending settings promise, and
+ * that promise instance is stable, so it suspends exactly once.
+ *
+ * The hash is updated with `replaceState` so a filter keystroke does not push
+ * a browser history entry per character.
  *
  * @param {string} key - The URL hash key
  * @param {Atom} defaultAtom - The atom providing server defaults
  * @returns {Atom} An atom with hash persistence and server fallback
  */
 const createHashAtomWithDefault = (key, defaultAtom) => {
-  const hashAtom = atomWithHash(key)
+  const hashAtom = atomWithHash(key, undefined, { setHash: 'replaceState' })
   return atom(
-    async (get) => {
+    (get) => {
       const hashValue = get(hashAtom)
       if (hashValue !== undefined && hashValue !== null) return hashValue
-      const defaultValue = get(defaultAtom)
-      return defaultValue instanceof Promise ? await defaultValue : defaultValue
+      return get(defaultAtom)
     },
     (get, set, value) => set(hashAtom, value),
   )

--- a/app-src/src/common/store/atoms/logsAtoms.js
+++ b/app-src/src/common/store/atoms/logsAtoms.js
@@ -27,6 +27,13 @@ export const logsLinesAtom = atomWithReset([])
 export const logsShowLogsAtom = atom(false)
 
 /**
+ * Logs stream error: holds the reason reported by the backend when the log
+ * stream could not be opened or was closed unexpectedly, so a failing request
+ * is not mistaken for a service without logs.
+ */
+export const logsErrorAtom = atomWithReset(null)
+
+/**
  * Logs number of lines: persists the number of log lines to fetch in URL hash, falling back to server default.
  */
 export const logsNumberOfLinesAtom = createHashAtomWithDefault(

--- a/app-src/src/common/store/atoms/themeAtoms.js
+++ b/app-src/src/common/store/atoms/themeAtoms.js
@@ -2,6 +2,7 @@ import { atom } from 'jotai'
 import {
   createHashAtomWithDefault,
   isDarkModeDefaultAtom,
+  mapMaybePromise,
 } from './foundationAtoms'
 
 const a11yDark = {}
@@ -18,24 +19,27 @@ export const isDarkModeAtom = createHashAtomWithDefault(
 /**
  * Current variant: derives 'dark' or 'light' string from the isDarkModeAtom for use with UI libraries.
  */
-export const currentVariantAtom = atom(async (get) => {
-  const isDarkMode = await get(isDarkModeAtom)
-  return isDarkMode ? 'dark' : 'light'
-})
+export const currentVariantAtom = atom((get) =>
+  mapMaybePromise(get(isDarkModeAtom), (isDarkMode) =>
+    isDarkMode ? 'dark' : 'light',
+  ),
+)
 
 /**
  * Current variant classes: derives Bootstrap CSS classes for the active theme variant.
  */
-export const currentVariantClassesAtom = atom(async (get) =>
-  (await get(isDarkModeAtom))
-    ? 'bg-dark text-light border-secondary'
-    : 'bg-light text-dark',
+export const currentVariantClassesAtom = atom((get) =>
+  mapMaybePromise(get(isDarkModeAtom), (isDarkMode) =>
+    isDarkMode ? 'bg-dark text-light border-secondary' : 'bg-light text-dark',
+  ),
 )
 
 /**
  * Current syntax highlighter style: derives the code syntax highlighting style for the active theme.
  */
-export const currentSyntaxHighlighterStyleAtom = atom(async (get) =>
+export const currentSyntaxHighlighterStyleAtom = atom((get) =>
   // keep API shape for tests/components — returns an object
-  (await get(isDarkModeAtom)) ? a11yDark : a11yLight,
+  mapMaybePromise(get(isDarkModeAtom), (isDarkMode) =>
+    isDarkMode ? a11yDark : a11yLight,
+  ),
 )

--- a/app-src/src/components/logs/LogsActiveControls.jsx
+++ b/app-src/src/components/logs/LogsActiveControls.jsx
@@ -6,6 +6,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { currentVariantAtom } from '../../common/store/atoms/themeAtoms'
 import {
   logsConfigAtom,
+  logsErrorAtom,
   logsLinesAtom,
   logsNumberOfLinesAtom,
   logsSearchKeywordAtom,
@@ -27,6 +28,7 @@ const LogsActiveControls = React.memo(function LogsActiveControls() {
   const [searchKeyword, setSearchKeyword] = useAtom(logsSearchKeywordAtom)
 
   const resetLogsLines = useResetAtom(logsLinesAtom)
+  const resetLogsError = useResetAtom(logsErrorAtom)
   const [, setLogsConfig] = useAtom(logsConfigAtom)
   const [, setLogsShowLogs] = useAtom(logsShowLogsAtom)
 
@@ -35,6 +37,7 @@ const LogsActiveControls = React.memo(function LogsActiveControls() {
     // reopening the logs UI. Only hide the logs output and clear
     // the live lines/config used for the current view.
     resetLogsLines()
+    resetLogsError()
     setLogsConfig(null)
     setLogsShowLogs(false)
   }

--- a/app-src/src/components/logs/LogsComponent.jsx
+++ b/app-src/src/components/logs/LogsComponent.jsx
@@ -1,10 +1,11 @@
 import React from 'react'
-import { useAtom, useAtomValue } from 'jotai'
+import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { Card } from 'react-bootstrap'
 import useWebSocket from 'react-use-websocket'
-import { useEffect, useCallback } from 'react'
+import { useCallback } from 'react'
 import {
   logsConfigAtom,
+  logsErrorAtom,
   logsLinesAtom,
   logsNumberOfLinesAtom,
   logsMessageMaxLenAtom,
@@ -15,6 +16,7 @@ import DSDCard from '../common/DSDCard.jsx'
 import LogsSetupForm from './LogsSetupForm.jsx'
 import LogsActiveControls from './LogsActiveControls.jsx'
 import LogsOutput from './LogsOutput'
+import { toLogLine } from './logsUtils'
 
 // Re-export for consumers that import isValidSince from this module
 export { isValidSince } from './logsUtils'
@@ -31,39 +33,50 @@ const LogsComponent = React.memo(function LogsComponent() {
   const [logsShowLogs] = useAtom(logsShowLogsAtom)
   const logsConfig = useAtomValue(logsConfigAtom)
   const logsWebsocketUrl = useAtomValue(logsWebsocketUrlAtom)
+  const setLogsError = useSetAtom(logsErrorAtom)
 
   const shouldReconnect = useCallback(() => {
     return Boolean(logsShowLogs && logsConfig?.follow)
   }, [logsShowLogs, logsConfig?.follow])
 
-  const { lastMessage } = useWebSocket(
+  // Append every incoming line from the websocket callback rather than from an
+  // effect on `lastMessage`. The backend emits one message per log line, so a
+  // burst of lines arrives faster than React re-renders: with `lastMessage`
+  // only the final line of each burst survived and the rest were silently
+  // dropped. The functional updater also keeps every line when several
+  // messages land in the same batch.
+  const handleMessage = useCallback(
+    (event) => {
+      const message = toLogLine(event?.data, logsMessageMaxLen)
+      const cap = Math.max(2 * Number(logsNumberOfLines) || 20, 20)
+      setLogsLines((prev) => [...prev, message].slice(-cap))
+    },
+    [logsNumberOfLines, logsMessageMaxLen, setLogsLines],
+  )
+
+  // The backend reports why a stream could not be served (an option Docker
+  // rejects, for instance) in the websocket close reason. Surfacing it keeps a
+  // failed request from looking like a service without any logs.
+  const handleClose = useCallback(
+    (event) => {
+      if (!event || event.code === 1000 || event.code === 1005) return
+      setLogsError(event.reason || `Log stream closed (code ${event.code})`)
+    },
+    [setLogsError],
+  )
+
+  const handleOpen = useCallback(() => setLogsError(null), [setLogsError])
+
+  useWebSocket(
     logsWebsocketUrl,
     {
+      onMessage: handleMessage,
+      onOpen: handleOpen,
+      onClose: handleClose,
       shouldReconnect: shouldReconnect,
     },
     logsShowLogs,
   )
-
-  useEffect(() => {
-    if (!lastMessage) return
-    const raw = lastMessage.data
-    let message
-    if (typeof raw === 'string') message = raw
-    else {
-      try {
-        message = JSON.stringify(raw)
-      } catch {
-        message = String(raw)
-      }
-    }
-    const maxLen = Number(logsMessageMaxLen) || 10000
-    if (message.length > maxLen) message = message.slice(0, maxLen) + '...'
-    setLogsLines((prev) => {
-      const cap = Math.max(2 * Number(logsNumberOfLines) || 20, 20)
-      const out = [...prev, message].slice(-cap)
-      return out
-    })
-  }, [lastMessage, logsNumberOfLines, logsMessageMaxLen, setLogsLines])
 
   return (
     <DSDCard

--- a/app-src/src/components/logs/LogsOutput.jsx
+++ b/app-src/src/components/logs/LogsOutput.jsx
@@ -1,8 +1,9 @@
 import { useAtomValue } from 'jotai'
-import { Button } from 'react-bootstrap'
+import { Alert, Button } from 'react-bootstrap'
 import React from 'react'
 import { currentVariantClassesAtom } from '../../common/store/atoms/themeAtoms'
 import {
+  logsErrorAtom,
   logsFormServiceIdAtom,
   logsFormServiceNameAtom,
   logsFormTailAtom,
@@ -60,6 +61,7 @@ const LogsOutput = React.memo(function LogsOutput() {
   const searchKeyword = useAtomValue(logsSearchKeywordAtom)
   const serviceId = useAtomValue(logsFormServiceIdAtom)
   const serviceName = useAtomValue(logsFormServiceNameAtom)
+  const logsError = useAtomValue(logsErrorAtom)
 
   const keyword = (searchKeyword ?? '').trim().toLowerCase()
   const sliced =
@@ -75,6 +77,11 @@ const LogsOutput = React.memo(function LogsOutput() {
       aria-live="polite"
       aria-label="Log output"
     >
+      {logsError && (
+        <Alert variant="danger" className="py-2 small">
+          {logsError}
+        </Alert>
+      )}
       <div className="font-monospace small">
         {keyword && (
           <div className="text-muted small mb-1">

--- a/app-src/src/components/logs/LogsSetupForm.jsx
+++ b/app-src/src/components/logs/LogsSetupForm.jsx
@@ -208,6 +208,11 @@ const LogsSetupForm = React.memo(function LogsSetupForm() {
                   <ListGroup.Item
                     key={'serviceList-' + service['ID']}
                     action
+                    // Action items render a bare <button>, which defaults to
+                    // type="submit" inside this form: picking a service would
+                    // submit it and start streaming the previously selected
+                    // service instead of this one.
+                    type="button"
                     active={serviceId === service['ID']}
                     onClick={() => {
                       setServiceId(service['ID'])

--- a/app-src/src/components/logs/LogsSetupForm.jsx
+++ b/app-src/src/components/logs/LogsSetupForm.jsx
@@ -22,6 +22,7 @@ import {
   logsFormDetailsAtom,
   logsSearchKeywordAtom,
   logsConfigAtom,
+  logsErrorAtom,
   logsShowLogsAtom,
   logsNumberOfLinesAtom,
 } from '../../common/store/atoms/logsAtoms'
@@ -54,6 +55,7 @@ const LogsSetupForm = React.memo(function LogsSetupForm() {
   const [, setSearchKeyword] = useAtom(logsSearchKeywordAtom)
   const [, setLogsNumberOfLines] = useAtom(logsNumberOfLinesAtom)
   const [, setLogsConfig] = useAtom(logsConfigAtom)
+  const [, setLogsError] = useAtom(logsErrorAtom)
   const [, setLogsShowLogs] = useAtom(logsShowLogsAtom)
 
   const [serviceSearch, setServiceSearch] = useState('')
@@ -80,6 +82,7 @@ const LogsSetupForm = React.memo(function LogsSetupForm() {
       return
     }
     setSinceError(false)
+    setLogsError(null)
     const newLogsConfig = {
       serviceId: serviceId,
       serviceName: serviceName || serviceNames[serviceId],

--- a/app-src/src/components/logs/logsUtils.js
+++ b/app-src/src/components/logs/logsUtils.js
@@ -10,3 +10,25 @@ export function isValidSince(s) {
   const d = Date.parse(s)
   return !Number.isNaN(d)
 }
+
+/**
+ * Converts a raw websocket payload into a log line, truncating overly long
+ * messages so a single huge line cannot freeze the output panel.
+ *
+ * @param {*} raw - the raw `MessageEvent.data` value
+ * @param {number|string} maxLen - maximum message length before truncation
+ * @returns {string} the log line to display
+ */
+export function toLogLine(raw, maxLen) {
+  let message
+  if (typeof raw === 'string') message = raw
+  else {
+    try {
+      message = JSON.stringify(raw)
+    } catch {
+      message = String(raw)
+    }
+  }
+  const limit = Number(maxLen) || 10000
+  return message.length > limit ? message.slice(0, limit) + '...' : message
+}

--- a/app-src/src/components/shared/names/ServiceName.jsx
+++ b/app-src/src/components/shared/names/ServiceName.jsx
@@ -1,12 +1,14 @@
 import React, { startTransition } from 'react'
 import PropTypes from 'prop-types'
 import { OverlayTrigger, Tooltip } from 'react-bootstrap'
-import { useAtom, useAtomValue } from 'jotai'
+import { useAtom } from 'jotai'
+import { useResetAtom } from 'jotai/utils'
 import EntityName from './EntityName'
 import {
   logsFormServiceIdAtom,
   logsFormServiceNameAtom,
   logsConfigAtom,
+  logsLinesAtom,
   logsShowLogsAtom,
 } from '../../../common/store/atoms/logsAtoms'
 import { viewAtom } from '../../../common/store/atoms/navigationAtoms'
@@ -16,35 +18,39 @@ import { logsId } from '../../../common/navigationConstants'
  * Internal function to handle logs button click
  * Extracted for better testability
  *
- * @param {string} sid - Service ID
- * @param {string} name - Service name
- * @param {boolean} logsShowLogsVal - Whether logs are currently being shown
- * @param {object} logsConfigVal - Current logs configuration
- * @param {Function} setLogsShowLogs - Setter for logs visibility
- * @param {Function} setLogsConfig - Setter for logs configuration
- * @param {Function} setFormId - Setter for form service ID
- * @param {Function} setFormName - Setter for form service name
- * @param {Function} updateView - Function to update the view
+ * @param {object} params - Handler parameters
+ * @param {string} params.serviceId - Service ID to preselect
+ * @param {string} params.serviceName - Service name to preselect
+ * @param {boolean} params.logsShowLogs - Whether a logs session is displayed
+ * @param {Function} params.setLogsShowLogs - Setter for logs visibility
+ * @param {Function} params.setLogsConfig - Setter for logs configuration
+ * @param {Function} params.resetLogsLines - Clears the collected log lines
+ * @param {Function} params.setFormId - Setter for form service ID
+ * @param {Function} params.setFormName - Setter for form service name
+ * @param {Function} params.updateView - Function to update the view
  */
-export function handleShowLogsInternal(
-  sid,
-  name,
-  logsShowLogsVal,
-  logsConfigVal,
+export function handleShowLogsInternal({
+  serviceId,
+  serviceName,
+  logsShowLogs,
   setLogsShowLogs,
   setLogsConfig,
+  resetLogsLines,
   setFormId,
   setFormName,
   updateView,
-) {
-  // If logs are currently being streamed (follow), close them first
-  if (logsShowLogsVal && logsConfigVal?.follow) {
+}) {
+  // Close any displayed logs session, streaming or not. The user asked for
+  // another service, and an open session would keep showing the previous one
+  // instead of the form prefilled below.
+  if (logsShowLogs) {
     setLogsShowLogs(false)
     setLogsConfig(null)
+    resetLogsLines()
   }
   // Prefill the logs form but DO NOT start streaming or set the active logs config.
-  setFormId(sid)
-  setFormName(name)
+  setFormId(serviceId)
+  setFormName(serviceName)
 
   // Navigate to logs view; the form will be shown because logsShowLogs is false
   updateView((prev) => ({ ...prev, id: logsId }))
@@ -68,7 +74,7 @@ const ServiceName = React.memo(function ServiceName({
   const [, setFormName] = useAtom(logsFormServiceNameAtom)
   const [, setLogsConfig] = useAtom(logsConfigAtom)
   const [logsShowLogsVal, setLogsShowLogs] = useAtom(logsShowLogsAtom)
-  const logsConfigVal = useAtomValue(logsConfigAtom)
+  const resetLogsLines = useResetAtom(logsLinesAtom)
   const [, updateView] = useAtom(viewAtom)
 
   if (!name) return null
@@ -96,17 +102,17 @@ const ServiceName = React.memo(function ServiceName({
 
   const handleShowLogs = (sid) => {
     startTransition(() => {
-      handleShowLogsInternal(
-        sid,
-        name,
-        logsShowLogsVal,
-        logsConfigVal,
+      handleShowLogsInternal({
+        serviceId: sid,
+        serviceName: name,
+        logsShowLogs: logsShowLogsVal,
         setLogsShowLogs,
         setLogsConfig,
+        resetLogsLines,
         setFormId,
         setFormName,
         updateView,
-      )
+      })
     })
   }
 

--- a/app-src/tests/unit/components/ServiceName.handleShowLogsInternal.test.js
+++ b/app-src/tests/unit/components/ServiceName.handleShowLogsInternal.test.js
@@ -7,107 +7,76 @@ describe('handleShowLogsInternal', () => {
   const mockSetters = {
     setLogsShowLogs: jest.fn(),
     setLogsConfig: jest.fn(),
+    resetLogsLines: jest.fn(),
     setFormId: jest.fn(),
     setFormName: jest.fn(),
     updateView: jest.fn(),
   }
+
+  const callHandler = (overrides = {}) =>
+    handleShowLogsInternal({
+      serviceId: 'svc-123',
+      serviceName: 'my-service',
+      logsShowLogs: false,
+      ...mockSetters,
+      ...overrides,
+    })
 
   beforeEach(() => {
     jest.clearAllMocks()
   })
 
   test('closes existing logs when follow is active', () => {
-    handleShowLogsInternal(
-      'svc-123',
-      'my-service',
-      true, // logsShowLogsVal - logs currently showing
-      { follow: true }, // logsConfigVal - follow mode active
-      mockSetters.setLogsShowLogs,
-      mockSetters.setLogsConfig,
-      mockSetters.setFormId,
-      mockSetters.setFormName,
-      mockSetters.updateView,
-    )
+    callHandler({ logsShowLogs: true })
 
     // Should close existing logs
     expect(mockSetters.setLogsShowLogs).toHaveBeenCalledWith(false)
     expect(mockSetters.setLogsConfig).toHaveBeenCalledWith(null)
-    
+
     // Should set form values
     expect(mockSetters.setFormId).toHaveBeenCalledWith('svc-123')
     expect(mockSetters.setFormName).toHaveBeenCalledWith('my-service')
-    
+
     // Should navigate to logs view
     expect(mockSetters.updateView).toHaveBeenCalled()
   })
 
-  test('does not close logs when follow is not active', () => {
-    handleShowLogsInternal(
-      'svc-123',
-      'my-service',
-      true, // logsShowLogsVal - logs currently showing
-      { follow: false }, // logsConfigVal - follow mode NOT active
-      mockSetters.setLogsShowLogs,
-      mockSetters.setLogsConfig,
-      mockSetters.setFormId,
-      mockSetters.setFormName,
-      mockSetters.updateView,
-    )
+  test('closes a displayed session even when follow is not active', () => {
+    // Picking another service must never leave the previous session on
+    // screen: it would keep showing the previously selected service.
+    callHandler({ logsShowLogs: true, serviceId: 'svc-y', serviceName: 'service-y' })
 
-    // Should NOT close logs (follow is not active)
-    expect(mockSetters.setLogsShowLogs).not.toHaveBeenCalled()
-    expect(mockSetters.setLogsConfig).not.toHaveBeenCalled()
-    
-    // Should still set form values
-    expect(mockSetters.setFormId).toHaveBeenCalledWith('svc-123')
-    expect(mockSetters.setFormName).toHaveBeenCalledWith('my-service')
-    
-    // Should navigate to logs view
+    expect(mockSetters.setLogsShowLogs).toHaveBeenCalledWith(false)
+    expect(mockSetters.setLogsConfig).toHaveBeenCalledWith(null)
+    expect(mockSetters.resetLogsLines).toHaveBeenCalled()
+    expect(mockSetters.setFormId).toHaveBeenCalledWith('svc-y')
+    expect(mockSetters.setFormName).toHaveBeenCalledWith('service-y')
     expect(mockSetters.updateView).toHaveBeenCalled()
   })
 
   test('works when logs are not currently showing', () => {
-    handleShowLogsInternal(
-      'svc-456',
-      'another-service',
-      false, // logsShowLogsVal - logs NOT showing
-      null, // logsConfigVal - no config
-      mockSetters.setLogsShowLogs,
-      mockSetters.setLogsConfig,
-      mockSetters.setFormId,
-      mockSetters.setFormName,
-      mockSetters.updateView,
-    )
+    callHandler({ serviceId: 'svc-456', serviceName: 'another-service' })
 
     // Should not try to close logs (they're not showing)
     expect(mockSetters.setLogsShowLogs).not.toHaveBeenCalled()
     expect(mockSetters.setLogsConfig).not.toHaveBeenCalled()
-    
+    expect(mockSetters.resetLogsLines).not.toHaveBeenCalled()
+
     // Should set form values
     expect(mockSetters.setFormId).toHaveBeenCalledWith('svc-456')
     expect(mockSetters.setFormName).toHaveBeenCalledWith('another-service')
-    
+
     // Should navigate to logs view
     expect(mockSetters.updateView).toHaveBeenCalled()
   })
 
   test('navigates to logs view with correct ID', () => {
-    handleShowLogsInternal(
-      'svc-789',
-      'test-service',
-      false,
-      null,
-      mockSetters.setLogsShowLogs,
-      mockSetters.setLogsConfig,
-      mockSetters.setFormId,
-      mockSetters.setFormName,
-      mockSetters.updateView,
-    )
+    callHandler({ serviceId: 'svc-789', serviceName: 'test-service' })
 
     // Check that updateView was called with a function
     expect(mockSetters.updateView).toHaveBeenCalledTimes(1)
     const updateFn = mockSetters.updateView.mock.calls[0][0]
-    
+
     // The function should set id to logsId ('logs')
     const result = updateFn({ otherProp: 'value' })
     expect(result).toMatchObject({ otherProp: 'value', id: 'logs' })

--- a/app-src/tests/unit/components/logs/LogsComponent.test.js
+++ b/app-src/tests/unit/components/logs/LogsComponent.test.js
@@ -1,0 +1,146 @@
+import { render } from '@testing-library/react'
+
+const mockUseAtomValue = jest.fn()
+const mockUseAtom = jest.fn()
+const mockSetLogsLines = jest.fn()
+const mockSetLogsError = jest.fn()
+
+// Captures the options object handed to useWebSocket so the test can drive the
+// socket callbacks directly.
+let websocketOptions = null
+
+jest.mock('react-use-websocket', () => ({
+  __esModule: true,
+  default: (url, options) => {
+    websocketOptions = options
+    return { lastMessage: null, readyState: 1 }
+  },
+}))
+
+jest.mock('../../../../src/common/store/atoms/logsAtoms', () => ({
+  logsConfigAtom: 'logsConfigAtom',
+  logsErrorAtom: 'logsErrorAtom',
+  logsLinesAtom: 'logsLinesAtom',
+  logsNumberOfLinesAtom: 'logsNumberOfLinesAtom',
+  logsMessageMaxLenAtom: 'logsMessageMaxLenAtom',
+  logsShowLogsAtom: 'logsShowLogsAtom',
+  logsWebsocketUrlAtom: 'logsWebsocketUrlAtom',
+}))
+
+jest.mock('jotai', () => ({
+  useAtomValue: (atom) => mockUseAtomValue(atom),
+  useAtom: (atom) => mockUseAtom(atom),
+  useSetAtom: () => mockSetLogsError,
+  Provider: ({ children }) => children,
+}))
+
+jest.mock('../../../../src/components/common/DSDCard.jsx', () => ({
+  __esModule: true,
+  default: ({ body }) => body,
+}))
+jest.mock('../../../../src/components/logs/LogsSetupForm.jsx', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+jest.mock('../../../../src/components/logs/LogsActiveControls.jsx', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+jest.mock('../../../../src/components/logs/LogsOutput', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+
+import LogsComponent from '../../../../src/components/logs/LogsComponent'
+
+const atoms = {
+  logsConfigAtom: { serviceId: 'abc', follow: false },
+  logsNumberOfLinesAtom: 50,
+  logsMessageMaxLenAtom: 10000,
+  logsShowLogsAtom: true,
+  logsWebsocketUrlAtom: 'ws://localhost/docker/logs/abc',
+}
+
+/** Applies the accumulated functional updates to an initial list of lines. */
+const applyUpdates = (initial = []) =>
+  mockSetLogsLines.mock.calls.reduce((lines, [updater]) => updater(lines), initial)
+
+describe('LogsComponent websocket handling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    websocketOptions = null
+    mockUseAtomValue.mockImplementation((atom) => atoms[atom] ?? null)
+    mockUseAtom.mockImplementation((atom) => {
+      if (atom === 'logsLinesAtom') return [[], mockSetLogsLines]
+      if (atom === 'logsShowLogsAtom') return [atoms.logsShowLogsAtom, jest.fn()]
+      return [null, jest.fn()]
+    })
+    render(<LogsComponent />)
+  })
+
+  test('keeps every line of a burst delivered between two renders', () => {
+    // The backend sends one websocket message per log line. Reading them from
+    // `lastMessage` used to collapse a burst into its final line only.
+    const burst = ['line-1', 'line-2', 'line-3', 'line-4', 'line-5']
+    burst.forEach((data) => websocketOptions.onMessage({ data }))
+
+    expect(applyUpdates()).toEqual(burst)
+  })
+
+  test('truncates messages longer than the configured maximum', () => {
+    mockUseAtomValue.mockImplementation((atom) =>
+      atom === 'logsMessageMaxLenAtom' ? 5 : (atoms[atom] ?? null),
+    )
+    jest.clearAllMocks()
+    render(<LogsComponent />)
+
+    websocketOptions.onMessage({ data: 'abcdefghij' })
+
+    expect(applyUpdates()).toEqual(['abcde...'])
+  })
+
+  test('caps the retained lines at twice the requested number of lines', () => {
+    mockUseAtomValue.mockImplementation((atom) =>
+      atom === 'logsNumberOfLinesAtom' ? 2 : (atoms[atom] ?? null),
+    )
+    jest.clearAllMocks()
+    render(<LogsComponent />)
+
+    for (let i = 0; i < 30; i++) websocketOptions.onMessage({ data: `l${i}` })
+
+    const lines = applyUpdates()
+    expect(lines).toHaveLength(20)
+    expect(lines[lines.length - 1]).toBe('l29')
+  })
+
+  test('reports an unexpected close reason as an error', () => {
+    websocketOptions.onClose({ code: 1011, reason: 'Docker logs error: boom' })
+
+    expect(mockSetLogsError).toHaveBeenCalledWith('Docker logs error: boom')
+  })
+
+  test('stays silent on a normal close', () => {
+    websocketOptions.onClose({ code: 1000, reason: '' })
+
+    expect(mockSetLogsError).not.toHaveBeenCalled()
+  })
+
+  test('clears a previous error when the socket opens', () => {
+    websocketOptions.onOpen({})
+
+    expect(mockSetLogsError).toHaveBeenCalledWith(null)
+  })
+
+  test('reconnects only while following', () => {
+    expect(websocketOptions.shouldReconnect()).toBe(false)
+
+    mockUseAtomValue.mockImplementation((atom) =>
+      atom === 'logsConfigAtom'
+        ? { serviceId: 'abc', follow: true }
+        : (atoms[atom] ?? null),
+    )
+    render(<LogsComponent />)
+
+    expect(websocketOptions.shouldReconnect()).toBe(true)
+  })
+})

--- a/app-src/tests/unit/components/logs/LogsSetupForm.serviceSelection.test.js
+++ b/app-src/tests/unit/components/logs/LogsSetupForm.serviceSelection.test.js
@@ -1,0 +1,144 @@
+// Regression tests for picking a service in the logs setup form.
+// The list items are rendered inside a <form>: as bare <button> elements they
+// defaulted to type="submit", so selecting a service submitted the form and
+// started a session for the previously selected service.
+import { render, screen, fireEvent } from '@testing-library/react'
+
+jest.mock('../../../../src/common/store/atoms/themeAtoms', () => ({
+  currentVariantAtom: 'currentVariantAtom',
+}))
+
+jest.mock('../../../../src/common/store/atoms/dashboardAtoms', () => ({
+  logsServicesAtom: 'logsServicesAtom',
+}))
+
+jest.mock('../../../../src/common/store/atoms/logsAtoms', () => ({
+  logsFormServiceIdAtom: 'logsFormServiceIdAtom',
+  logsFormServiceNameAtom: 'logsFormServiceNameAtom',
+  logsFormTailAtom: 'logsFormTailAtom',
+  logsFormSinceAtom: 'logsFormSinceAtom',
+  logsFormSinceErrorAtom: 'logsFormSinceErrorAtom',
+  logsFormSinceAmountAtom: 'logsFormSinceAmountAtom',
+  logsFormSinceUnitAtom: 'logsFormSinceUnitAtom',
+  logsFormSinceIsISOAtom: 'logsFormSinceIsISOAtom',
+  logsFormShowAdvancedAtom: 'logsFormShowAdvancedAtom',
+  logsFormFollowAtom: 'logsFormFollowAtom',
+  logsFormTimestampsAtom: 'logsFormTimestampsAtom',
+  logsFormStdoutAtom: 'logsFormStdoutAtom',
+  logsFormStderrAtom: 'logsFormStderrAtom',
+  logsFormDetailsAtom: 'logsFormDetailsAtom',
+  logsSearchKeywordAtom: 'logsSearchKeywordAtom',
+  logsNumberOfLinesAtom: 'logsNumberOfLinesAtom',
+  logsConfigAtom: 'logsConfigAtom',
+  logsErrorAtom: 'logsErrorAtom',
+  logsShowLogsAtom: 'logsShowLogsAtom',
+}))
+
+const mockUseAtomValue = jest.fn()
+const mockUseAtom = jest.fn()
+jest.mock('jotai', () => ({
+  atom: (v) => v,
+  useAtomValue: (...args) => mockUseAtomValue(...args),
+  useAtom: (...args) => mockUseAtom(...args),
+}))
+
+jest.mock('../../../../src/components/logs/SinceInput', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+jest.mock('@fortawesome/react-fontawesome', () => ({
+  FontAwesomeIcon: () => null,
+}))
+
+import LogsSetupForm from '../../../../src/components/logs/LogsSetupForm'
+
+const services = [
+  { ID: 'svc-x', Name: 'service-x' },
+  { ID: 'svc-y', Name: 'service-y' },
+]
+
+const setters = {
+  setServiceId: jest.fn(),
+  setServiceName: jest.fn(),
+  setLogsConfig: jest.fn(),
+  setLogsShowLogs: jest.fn(),
+}
+
+/** Renders the form with `serviceId` already selected. */
+function renderForm(serviceId = '', serviceName = '') {
+  const values = {
+    logsFormServiceIdAtom: serviceId,
+    logsFormServiceNameAtom: serviceName,
+    logsFormTailAtom: '20',
+    logsFormSinceAtom: '1h',
+    logsFormSinceErrorAtom: false,
+    logsFormSinceAmountAtom: '1',
+    logsFormSinceUnitAtom: 'h',
+    logsFormSinceIsISOAtom: false,
+    logsFormShowAdvancedAtom: false,
+    logsFormFollowAtom: false,
+    logsFormTimestampsAtom: false,
+    logsFormStdoutAtom: true,
+    logsFormStderrAtom: true,
+    logsFormDetailsAtom: false,
+    logsSearchKeywordAtom: '',
+    logsNumberOfLinesAtom: 20,
+    logsConfigAtom: null,
+    logsErrorAtom: null,
+    logsShowLogsAtom: false,
+  }
+  mockUseAtom.mockImplementation((atom) => {
+    switch (atom) {
+      case 'logsFormServiceIdAtom':
+        return [serviceId, setters.setServiceId]
+      case 'logsFormServiceNameAtom':
+        return [serviceName, setters.setServiceName]
+      case 'logsConfigAtom':
+        return [null, setters.setLogsConfig]
+      case 'logsShowLogsAtom':
+        return [false, setters.setLogsShowLogs]
+      default:
+        return [values[atom], jest.fn()]
+    }
+  })
+  mockUseAtomValue.mockImplementation((atom) =>
+    atom === 'logsServicesAtom'
+      ? services
+      : atom === 'currentVariantAtom'
+        ? 'light'
+        : values[atom],
+  )
+  return render(<LogsSetupForm />)
+}
+
+describe('LogsSetupForm service selection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('service list items are plain buttons, not form submitters', () => {
+    renderForm()
+
+    for (const name of ['service-x', 'service-y']) {
+      expect(screen.getByText(name).closest('button')).toHaveAttribute(
+        'type',
+        'button',
+      )
+    }
+  })
+
+  test('picking a service selects it without starting a session', () => {
+    // A previously selected service (X) is what a submit would have streamed.
+    renderForm('svc-x', 'service-x')
+
+    // Reopen the list, then pick the other service.
+    fireEvent.click(screen.getByLabelText('Change service'))
+    renderForm()
+    fireEvent.click(screen.getAllByText('service-y')[0])
+
+    expect(setters.setServiceId).toHaveBeenCalledWith('svc-y')
+    expect(setters.setServiceName).toHaveBeenCalledWith('service-y')
+    expect(setters.setLogsShowLogs).not.toHaveBeenCalled()
+    expect(setters.setLogsConfig).not.toHaveBeenCalled()
+  })
+})

--- a/app-src/tests/unit/components/logs/toLogLine.test.js
+++ b/app-src/tests/unit/components/logs/toLogLine.test.js
@@ -1,0 +1,26 @@
+import { toLogLine } from '../../../../src/components/logs/logsUtils'
+
+describe('toLogLine', () => {
+  test('passes strings through unchanged', () => {
+    expect(toLogLine('hello world', 10000)).toBe('hello world')
+  })
+
+  test('truncates messages beyond the maximum length', () => {
+    expect(toLogLine('abcdefghij', 4)).toBe('abcd...')
+  })
+
+  test('falls back to 10000 characters for an unusable maximum', () => {
+    const long = 'x'.repeat(10050)
+    expect(toLogLine(long, 'not-a-number')).toBe('x'.repeat(10000) + '...')
+  })
+
+  test('serializes non-string payloads', () => {
+    expect(toLogLine({ msg: 'hi' }, 10000)).toBe('{"msg":"hi"}')
+  })
+
+  test('stringifies payloads that cannot be serialized', () => {
+    const circular = {}
+    circular.self = circular
+    expect(toLogLine(circular, 10000)).toBe('[object Object]')
+  })
+})

--- a/app-src/tests/unit/components/shared/names/ServiceName.logic.test.js
+++ b/app-src/tests/unit/components/shared/names/ServiceName.logic.test.js
@@ -7,95 +7,71 @@ import { logsId } from '../../../../../src/common/navigationConstants'
 describe('ServiceName handleShowLogsInternal', () => {
   const mockSetLogsShowLogs = jest.fn()
   const mockSetLogsConfig = jest.fn()
+  const mockResetLogsLines = jest.fn()
   const mockSetFormId = jest.fn()
   const mockSetFormName = jest.fn()
   const mockUpdateView = jest.fn()
+
+  const callHandler = (logsShowLogs) =>
+    handleShowLogsInternal({
+      serviceId: 'test-id',
+      serviceName: 'test-service',
+      logsShowLogs,
+      setLogsShowLogs: mockSetLogsShowLogs,
+      setLogsConfig: mockSetLogsConfig,
+      resetLogsLines: mockResetLogsLines,
+      setFormId: mockSetFormId,
+      setFormName: mockSetFormName,
+      updateView: mockUpdateView,
+    })
 
   beforeEach(() => {
     jest.clearAllMocks()
   })
 
   test('handles logs button click when logs are not showing', () => {
-    handleShowLogsInternal(
-      'test-id',
-      'test-service',
-      false,  // logsShowLogsVal
-      null,   // logsConfigVal
-      mockSetLogsShowLogs,
-      mockSetLogsConfig,
-      mockSetFormId,
-      mockSetFormName,
-      mockUpdateView
-    )
-    
+    callHandler(false)
+
     expect(mockSetLogsShowLogs).not.toHaveBeenCalled()
     expect(mockSetLogsConfig).not.toHaveBeenCalled()
+    expect(mockResetLogsLines).not.toHaveBeenCalled()
     expect(mockSetFormId).toHaveBeenCalledWith('test-id')
     expect(mockSetFormName).toHaveBeenCalledWith('test-service')
     expect(mockUpdateView).toHaveBeenCalled()
-    
+
     // Check that the updateView function was called with a function
     const updateViewArg = mockUpdateView.mock.calls[0][0]
     expect(updateViewArg).toBeInstanceOf(Function)
-    
+
     // Test the function that was passed to updateView
     const result = updateViewArg({})
     expect(result.id).toBe(logsId)
   })
 
-  test('handles logs button click when logs are showing with follow', () => {
-    handleShowLogsInternal(
-      'test-id',
-      'test-service',
-      true,   // logsShowLogsVal
-      { follow: true },  // logsConfigVal
-      mockSetLogsShowLogs,
-      mockSetLogsConfig,
-      mockSetFormId,
-      mockSetFormName,
-      mockUpdateView
-    )
-    
+  test('closes the current session when logs are showing', () => {
+    callHandler(true)
+
     expect(mockSetLogsShowLogs).toHaveBeenCalledWith(false)
     expect(mockSetLogsConfig).toHaveBeenCalledWith(null)
+    expect(mockResetLogsLines).toHaveBeenCalled()
     expect(mockSetFormId).toHaveBeenCalledWith('test-id')
     expect(mockSetFormName).toHaveBeenCalledWith('test-service')
     expect(mockUpdateView).toHaveBeenCalled()
-    
+
     // Check that the updateView function was called with a function
     const updateViewArg = mockUpdateView.mock.calls[0][0]
     expect(updateViewArg).toBeInstanceOf(Function)
-    
+
     // Test the function that was passed to updateView
     const result = updateViewArg({})
     expect(result.id).toBe(logsId)
   })
 
-  test('handles logs button click when logs are showing without follow', () => {
-    handleShowLogsInternal(
-      'test-id',
-      'test-service',
-      true,   // logsShowLogsVal
-      { follow: false },  // logsConfigVal
-      mockSetLogsShowLogs,
-      mockSetLogsConfig,
-      mockSetFormId,
-      mockSetFormName,
-      mockUpdateView
-    )
-    
-    expect(mockSetLogsShowLogs).not.toHaveBeenCalled()
-    expect(mockSetLogsConfig).not.toHaveBeenCalled()
-    expect(mockSetFormId).toHaveBeenCalledWith('test-id')
-    expect(mockSetFormName).toHaveBeenCalledWith('test-service')
-    expect(mockUpdateView).toHaveBeenCalled()
-    
-    // Check that the updateView function was called with a function
-    const updateViewArg = mockUpdateView.mock.calls[0][0]
-    expect(updateViewArg).toBeInstanceOf(Function)
-    
-    // Test the function that was passed to updateView
-    const result = updateViewArg({})
-    expect(result.id).toBe(logsId)
+  test('discards the lines of the previous service', () => {
+    callHandler(true)
+
+    // The output panel must not mix the previous service's lines with the
+    // ones fetched for the newly selected service.
+    expect(mockResetLogsLines).toHaveBeenCalledTimes(1)
   })
 })

--- a/app-src/tests/unit/store/hashAtomWithDefault.test.js
+++ b/app-src/tests/unit/store/hashAtomWithDefault.test.js
@@ -1,0 +1,71 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Regression tests for createHashAtomWithDefault, exercised against a real
+ * Jotai store (no mocks) because the bug they guard against lives in the
+ * synchronous/asynchronous nature of the atom itself.
+ */
+
+import { atom, createStore } from 'jotai'
+import { createHashAtomWithDefault } from '../../../src/common/store/atoms/foundationAtoms'
+
+describe('createHashAtomWithDefault', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, '', window.location.pathname)
+  })
+
+  test('falls back to the server default while no hash value is set', async () => {
+    const defaultAtom = atom(async () => 'from-server')
+    const hashAtom = createHashAtomWithDefault('probeA', defaultAtom)
+    const store = createStore()
+
+    await expect(store.get(hashAtom)).resolves.toBe('from-server')
+  })
+
+  test('returns the same pending promise instance on repeated reads', () => {
+    const defaultAtom = atom(async () => 'from-server')
+    const hashAtom = createHashAtomWithDefault('probeB', defaultAtom)
+    const store = createStore()
+
+    // A new promise per read would make consumers suspend over and over.
+    expect(store.get(hashAtom)).toBe(store.get(hashAtom))
+  })
+
+  test('resolves synchronously once a value has been written', () => {
+    const defaultAtom = atom(async () => 'from-server')
+    const hashAtom = createHashAtomWithDefault('probeC', defaultAtom)
+    const store = createStore()
+
+    store.set(hashAtom, 'ngin')
+
+    // This is the guarantee that keeps keyboard focus alive: an async read
+    // would hand out a fresh pending promise on every keystroke, suspending
+    // the view and remounting the whole subtree under <Suspense>.
+    const value = store.get(hashAtom)
+    expect(value).not.toBeInstanceOf(Promise)
+    expect(value).toBe('ngin')
+  })
+
+  test('persists the value in the URL hash', () => {
+    const defaultAtom = atom(async () => 'from-server')
+    const hashAtom = createHashAtomWithDefault('probeD', defaultAtom)
+    const store = createStore()
+
+    store.set(hashAtom, 'nginx')
+
+    expect(decodeURIComponent(window.location.hash)).toContain('probeD="nginx"')
+  })
+
+  test('replaces history entries instead of pushing one per keystroke', () => {
+    const defaultAtom = atom(async () => 'from-server')
+    const hashAtom = createHashAtomWithDefault('probeE', defaultAtom)
+    const store = createStore()
+
+    const initialLength = window.history.length
+    for (const value of ['n', 'ng', 'ngi', 'ngin', 'nginx']) {
+      store.set(hashAtom, value)
+    }
+
+    expect(window.history.length).toBe(initialLength)
+  })
+})

--- a/server-src/docker_service_logs_handler.go
+++ b/server-src/docker_service_logs_handler.go
@@ -8,8 +8,9 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"regexp"
 	"strconv"
-	"sync"
+	"strings"
 	"time"
 
 	"github.com/docker/docker/api/types/container"
@@ -33,6 +34,23 @@ var pingInterval = 54 * time.Second
 
 // writeWait is the timeout for websocket write operations.
 const writeWait = 10 * time.Second
+
+// pongWait is how long the client may stay silent before its connection is
+// considered dead. It must be longer than pingInterval.
+const pongWait = 60 * time.Second
+
+// logChannelSize bounds how many log lines may wait for a slow client. A full
+// channel applies backpressure on the docker reader instead of buffering
+// without limit.
+const logChannelSize = 64
+
+// tailCollectIdle is how long the one-shot reader waits for another line
+// before considering the log output complete. Docker keeps the response open
+// for some non-follow requests, so waiting for EOF alone would block.
+const tailCollectIdle = 100 * time.Millisecond
+
+// defaultTail is used when the client requests an unparsable number of lines.
+const defaultTail = 20
 
 // sendTextMessage sets a write deadline and sends a text message.
 func sendTextMessage(conn *websocket.Conn, data []byte) error {
@@ -100,245 +118,271 @@ func processPayload(conn *websocket.Conn, payload []byte) error {
 	return nil
 }
 
-// dockerServiceLogsHandler handles websocket connections for streaming
-// Docker service logs to a connected client. The handler upgrades the
-// HTTP connection to a websocket, starts a goroutine that writes
-// log lines to the client and reads the Docker logs. It keeps a
-// buffered channel between reader and writer and closes the
-// connection when the client is too slow to consume messages.
+// logsOptions holds the parameters of a logs websocket request.
+type logsOptions struct {
+	serviceID  string
+	tail       string
+	since      string
+	follow     bool
+	timestamps bool
+	stdout     bool
+	stderr     bool
+	details    bool
+}
+
+// dayDurationPattern matches a relative duration expressed in days, e.g. "2d".
+var dayDurationPattern = regexp.MustCompile(`^(\d+)d$`)
+
+// normalizeSince rewrites a relative `since` value into a unit the Docker
+// client understands. It resolves relative values with `time.ParseDuration`,
+// which supports "s", "m" and "h" but *not* days: a request for "2d" would
+// fail outright and the client would receive no logs at all. Days are
+// therefore expanded into hours. Absolute timestamps are passed through
+// untouched.
+func normalizeSince(since string) string {
+	if match := dayDurationPattern.FindStringSubmatch(strings.TrimSpace(since)); match != nil {
+		if days, err := strconv.Atoi(match[1]); err == nil {
+			return strconv.Itoa(days*24) + "h"
+		}
+	}
+	return since
+}
+
+// parseLogsOptions extracts the log parameters from the request. Absent or
+// unparsable parameters fall back to defaults rather than failing the request.
+func parseLogsOptions(r *http.Request) logsOptions {
+	query := r.URL.Query()
+	boolParam := func(key string) bool {
+		value, _ := strconv.ParseBool(query.Get(key))
+		return value
+	}
+	tail := query.Get("tail")
+	if tail == "" {
+		tail = "all"
+	}
+	return logsOptions{
+		serviceID:  mux.Vars(r)["id"],
+		tail:       tail,
+		since:      normalizeSince(query.Get("since")),
+		follow:     boolParam("follow"),
+		timestamps: boolParam("timestamps"),
+		stdout:     boolParam("stdout"),
+		stderr:     boolParam("stderr"),
+		details:    boolParam("details"),
+	}
+}
+
+// tailCount returns the number of lines a one-shot request asked for.
+func tailCount(tail string) int {
+	if n, err := strconv.Atoi(tail); err == nil && n > 0 {
+		return n
+	}
+	return defaultTail
+}
+
+// stripFramePrefix removes Docker's 8-byte multiplex header from a single log
+// line. It returns nil when the line carries no payload.
+func stripFramePrefix(line []byte) []byte {
+	if len(line) <= 8 {
+		return nil
+	}
+	return append([]byte(nil), line[8:]...)
+}
+
+// dockerServiceLogsHandler streams the logs of a Docker service over a
+// websocket.
+//
+// A single context governs the whole request: it is cancelled when the handler
+// returns or when the client disconnects, which closes the Docker log reader
+// and unblocks every goroutine started here. Log lines travel over one
+// channel, owned and closed by the reader, so no extra synchronisation is
+// needed between the reader and the writer.
 func dockerServiceLogsHandler(w http.ResponseWriter, r *http.Request) {
-	params := mux.Vars(r)
-	paramServiceId := params["id"]
+	opts := parseLogsOptions(r)
 
-	urlParams := r.URL.Query()
-	paramTail := urlParams["tail"][0]
-	paramSince := urlParams["since"][0]
-	paramStdout, _ := strconv.ParseBool(urlParams["stdout"][0])
-	paramStderr, _ := strconv.ParseBool(urlParams["stderr"][0])
-	paramFollow, _ := strconv.ParseBool(urlParams["follow"][0])
-	paramTimestamps, _ := strconv.ParseBool(urlParams["timestamps"][0])
-	paramDetails, _ := strconv.ParseBool(urlParams["details"][0])
-	clientAddress := string(r.RemoteAddr)
+	clientAddress := r.RemoteAddr
 	log.Println("new logs-websocket-connection:", clientAddress)
-	ce, err := upgrader.Upgrade(w, r, nil)
 
+	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		log.Print("upgrade:", err)
 		return
 	}
-	defer func() { _ = ce.Close() }()
+	defer func() { _ = conn.Close() }()
 	defer log.Println("gone:", clientAddress)
 
-	// docker-client context
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
 	cli, err := getCli()
 	if err != nil {
 		log.Printf("dockerServiceLogsHandler: getCli error: %v", err)
-		_ = ce.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseInternalServerErr, "Docker client error"))
+		closeWithError(conn, "Docker client error")
 		return
 	}
-	logReader, err := cli.ServiceLogs(ctx, paramServiceId, container.LogsOptions{
-		Tail:       paramTail,
-		Since:      paramSince,
-		Follow:     paramFollow,
-		Timestamps: paramTimestamps,
-		ShowStdout: paramStdout,
-		ShowStderr: paramStderr,
-		Details:    paramDetails,
+
+	logReader, err := cli.ServiceLogs(ctx, opts.serviceID, container.LogsOptions{
+		Tail:       opts.tail,
+		Since:      opts.since,
+		Follow:     opts.follow,
+		Timestamps: opts.timestamps,
+		ShowStdout: opts.stdout,
+		ShowStderr: opts.stderr,
+		Details:    opts.details,
 	})
 	if err != nil {
+		// Report the reason to the client: an unusable option (an invalid
+		// `since` for instance) would otherwise look like a service with no
+		// logs at all.
 		log.Printf("dockerServiceLogsHandler: ServiceLogs error: %v", err)
-		_ = ce.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseInternalServerErr, "Docker logs error"))
+		closeWithError(conn, "Docker logs error: "+err.Error())
 		return
 	}
-
-	// Ensure reader closed when set (cli.ServiceLogs returns an io.ReadCloser).
-	if logReader != nil {
-		defer func() { _ = logReader.Close() }()
-	}
-
-	// Buffered channel decouples the Docker log read from websocket writes.
-	// Reduce buffer size so slow-client behavior is detected reliably in tests.
-	const channelSize = 64
-	channel := make(chan []byte, channelSize)
-	// closeChan ensures the channel is closed exactly once.
-	var closeChanOnce sync.Once
-
-	// If the client requested a one-shot (follow=false), read the entire
-	// log payload, parse multiplex frames if present, and send exactly the
-	// requested tail number of log lines, then exit. This guarantees the
-	// client receives the last N lines and nothing more.
-	if !paramFollow {
-		// read lines incrementally (don't block waiting for EOF). Some
-		// Docker endpoints keep the connection open even for non-follow
-		// requests; reading with ReadLine returns available lines without
-		// waiting for EOF. Start a goroutine that reads lines and send
-		// them over a channel, then collect with a short idle timeout.
-		bufioReader := bufio.NewReader(logReader)
-		linesCh := make(chan string, 64)
-		go func() {
-			defer close(linesCh)
-			for {
-				line, _, err := bufioReader.ReadLine()
-				if err != nil {
-					return
-				}
-				// copy line bytes and strip Docker's 8-byte prefix if present
-				b := make([]byte, len(line))
-				copy(b, line)
-				if len(b) > 8 {
-					b = b[8:]
-				} else {
-					b = b[:0]
-				}
-				if len(b) == 0 {
-					continue
-				}
-				linesCh <- string(b)
-			}
-		}()
-
-		// collect lines until idle timeout
-		var lines []string
-		idle := 100 * time.Millisecond
-		timer := time.NewTimer(idle)
-		// stop the timer initially until first line arrives
-		if !timer.Stop() {
-			<-timer.C
-		}
-		collecting := true
-		for collecting {
-			select {
-			case l, ok := <-linesCh:
-				if !ok {
-					collecting = false
-					break
-				}
-				lines = append(lines, l)
-				// reset idle timer
-				if !timer.Stop() {
-					select {
-					case <-timer.C:
-					default:
-					}
-				}
-				timer.Reset(idle)
-			case <-timer.C:
-				collecting = false
-			}
-		}
-		timer.Stop()
-		// ensure reader is closed to unblock underlying connection
-		if logReader != nil {
-			_ = logReader.Close()
-		}
-		// determine requested tail and send only those lines
-		tailNum := 20
-		if n, err := strconv.Atoi(paramTail); err == nil && n > 0 {
-			tailNum = n
-		}
-		start := 0
-		if len(lines) > tailNum {
-			start = len(lines) - tailNum
-		}
-		for i := start; i < len(lines); i++ {
-			if err := sendTextMessage(ce, []byte(lines[i])); err != nil {
-				log.Printf("Websocket write failed: %v", err)
-				_ = ce.Close()
-				return
-			}
-		}
-		// close normally
-		_ = ce.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+	if logReader == nil {
+		log.Printf("dockerServiceLogsHandler: no log stream for service %s", opts.serviceID)
+		closeWithError(conn, "Docker returned no log stream")
 		return
 	}
+	defer func() { _ = logReader.Close() }()
 
-	// Start a single goroutine that serializes writes to the websocket.
-	// Keep a done channel so we can wait for the writer to finish when
-	// we need to close the connection to avoid racing with ongoing writes.
-	writerDone := make(chan struct{})
+	// Closing the reader is the only way to unblock a pending read, so tie it
+	// to the context: cancelling stops the reader goroutine for good.
 	go func() {
-		writeLogPipeToClient(ce, channel)
-		close(writerDone)
+		<-ctx.Done()
+		_ = logReader.Close()
 	}()
 
-	// Configure read limits and keep-alive (pong handler) for the client
-	// connection so we detect broken peers.
-	ce.SetReadLimit(1024 * 1024)
-	_ = ce.SetReadDeadline(time.Now().Add(60 * time.Second))
-	ce.SetPongHandler(func(string) error {
-		_ = ce.SetReadDeadline(time.Now().Add(60 * time.Second))
-		return nil
-	})
-
-	// Start a goroutine that reads client messages and closes the
-	// connection when the client disconnects. We don't expect client
-	// messages, but ReadMessage is used to detect disconnects reliably.
+	// The client is not expected to send anything; reading detects a
+	// disconnect. Closing the connection makes any pending write fail, which
+	// stops the streaming loop below.
 	go func() {
+		defer cancel()
 		for {
-			if _, _, err := ce.ReadMessage(); err != nil {
-				_ = ce.Close()
+			if _, _, err := conn.ReadMessage(); err != nil {
+				_ = conn.Close()
 				return
 			}
 		}
 	}()
 
-	// Read the docker logs line-by-line and enqueue them. If the channel
-	// is full, treat the client as too slow: close the channel and wait
-	// for the writer to finish before closing the websocket.
-	bufioReader := bufio.NewReader(logReader)
+	if opts.follow {
+		streamLogs(ctx, conn, logReader)
+		return
+	}
+	sendLogTail(ctx, conn, logReader, tailCount(opts.tail))
+}
+
+// closeWithError closes the websocket with an internal-error close frame
+// carrying a human readable reason.
+func closeWithError(conn *websocket.Conn, reason string) {
+	// Close reasons are capped at 123 bytes by the websocket protocol; drop a
+	// rune left incomplete by the cut so the frame stays valid UTF-8.
+	if len(reason) > 123 {
+		reason = strings.ToValidUTF8(reason[:123], "")
+	}
+	_ = conn.WriteMessage(websocket.CloseMessage,
+		websocket.FormatCloseMessage(websocket.CloseInternalServerErr, reason))
+}
+
+// readLogLines reads the Docker log stream line by line and forwards each line
+// to `lines`. It owns the channel and closes it when the stream ends, the
+// context is cancelled or reading fails.
+func readLogLines(ctx context.Context, logReader io.Reader, lines chan<- []byte) {
+	defer close(lines)
+	reader := bufio.NewReader(logReader)
 	for {
-		line, _, err := bufioReader.ReadLine()
-		if err == io.EOF {
-			log.Println("logs EOF for service:", paramServiceId)
-			break
-		}
+		line, _, err := reader.ReadLine()
 		if err != nil {
-			log.Println(err)
+			if err != io.EOF && ctx.Err() == nil {
+				log.Printf("reading docker logs failed: %v", err)
+			}
 			return
 		}
-
-		// Copy the line before sending because bufio.Reader may reuse
-		// the underlying buffer across ReadLine calls; sharing that
-		// backing array concurrently causes data races when the writer
-		// reads the slice. Allocate a fresh slice and copy the data.
-		lineCopy := make([]byte, len(line))
-		copy(lineCopy, line)
-
-		// Try to enqueue the line; if the channel is full, wait briefly
-		// for the writer to make progress. This avoids flaky failures
-		// where scheduling differences prevent the writer from emptying
-		// the channel immediately. If the channel stays full for the
-		// timeout, treat the client as too slow and close the connection.
+		// bufio reuses its buffer across reads, so the consumer gets its own
+		// copy of the data.
+		lineCopy := append([]byte(nil), line...)
 		select {
-		case channel <- lineCopy:
-			// enqueued successfully
-		default:
-			// wait briefly for the writer to free up space
-			select {
-			case channel <- lineCopy:
-				// enqueued on second attempt
-			case <-time.After(50 * time.Millisecond):
-				// Slow/unresponsive client: close the channel so the writer
-				// will stop. Then wait briefly for the writer to finish to
-				// avoid WriteMessage racing with connection Close.
-				log.Printf("client too slow, closing websocket for service: %s", paramServiceId)
-				closeChanOnce.Do(func() { close(channel) })
-				select {
-				case <-writerDone:
-					// writer finished
-				case <-time.After(2 * time.Second):
-					log.Printf("writer did not finish in time for service: %s", paramServiceId)
-				}
-				_ = ce.Close()
-				return
-			}
+		case lines <- lineCopy:
+		case <-ctx.Done():
+			return
 		}
 	}
+}
 
-	// Normal exit: close the channel so the writer can finish.
-	closeChanOnce.Do(func() { close(channel) })
+// streamLogs pipes the Docker log stream to the client until the stream ends
+// or the connection breaks. A full channel applies backpressure on the reader
+// instead of dropping the connection, and a client that stops consuming
+// altogether is dropped by the write deadline in writeLogPipeToClient.
+func streamLogs(ctx context.Context, conn *websocket.Conn, logReader io.Reader) {
+	conn.SetReadLimit(1024 * 1024)
+	_ = conn.SetReadDeadline(time.Now().Add(pongWait))
+	conn.SetPongHandler(func(string) error {
+		return conn.SetReadDeadline(time.Now().Add(pongWait))
+	})
+
+	lines := make(chan []byte, logChannelSize)
+	go readLogLines(ctx, logReader, lines)
+	writeLogPipeToClient(conn, lines)
+}
+
+// sendLogTail answers a one-shot request: it collects the available log lines,
+// sends the last `tail` of them and closes the connection normally. Docker
+// keeps the response open for some non-follow requests, so collection ends on
+// an idle timeout rather than on EOF alone.
+func sendLogTail(ctx context.Context, conn *websocket.Conn, logReader io.Reader, tail int) {
+	lines := collectLogLines(ctx, logReader, tailCollectIdle)
+
+	start := 0
+	if len(lines) > tail {
+		start = len(lines) - tail
+	}
+	for _, line := range lines[start:] {
+		if err := sendTextMessage(conn, line); err != nil {
+			log.Printf("Websocket write failed: %v", err)
+			return
+		}
+	}
+	_ = conn.WriteMessage(websocket.CloseMessage,
+		websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+}
+
+// collectLogLines gathers log lines until the stream ends, the context is
+// cancelled or no new line arrived for `idle`.
+func collectLogLines(ctx context.Context, logReader io.Reader, idle time.Duration) [][]byte {
+	raw := make(chan []byte, logChannelSize)
+	go readLogLines(ctx, logReader, raw)
+
+	var lines [][]byte
+	// The timer only limits the gap *between* lines: it starts once the first
+	// line has arrived, so a slow first response does not truncate the output.
+	timer := time.NewTimer(idle)
+	if !timer.Stop() {
+		<-timer.C
+	}
+	defer timer.Stop()
+
+	for {
+		select {
+		case line, ok := <-raw:
+			if !ok {
+				return lines
+			}
+			if payload := stripFramePrefix(line); len(payload) > 0 {
+				lines = append(lines, payload)
+			}
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			timer.Reset(idle)
+		case <-timer.C:
+			return lines
+		case <-ctx.Done():
+			return lines
+		}
+	}
 }
 
 // writeLogPipeToClient serializes writes to the websocket connection.

--- a/server-src/docker_service_logs_options_test.go
+++ b/server-src/docker_service_logs_options_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/gorilla/websocket"
+)
+
+// TestNormalizeSince verifies that day-based durations are rewritten into
+// hours, since Go's time.ParseDuration — used by the Docker client to resolve
+// a relative `since` — does not understand days.
+func TestNormalizeSince(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"1d", "24h"},
+		{"2d", "48h"},
+		{" 7d ", "168h"},
+		{"5m", "5m"},
+		{"6h", "6h"},
+		{"30s", "30s"},
+		{"0", "0"},
+		{"", ""},
+		{"2023-01-01T12:00:00Z", "2023-01-01T12:00:00Z"},
+	}
+	for _, tc := range cases {
+		if got := normalizeSince(tc.in); got != tc.want {
+			t.Errorf("normalizeSince(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestParseLogsOptionsDefaults verifies that missing query parameters do not
+// break the request.
+func TestParseLogsOptionsDefaults(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/docker/logs/svc1", nil)
+	opts := parseLogsOptions(r)
+
+	if opts.tail != "all" {
+		t.Errorf("expected tail default 'all', got %q", opts.tail)
+	}
+	if opts.follow || opts.stdout || opts.stderr || opts.timestamps || opts.details {
+		t.Errorf("expected all boolean options to default to false, got %+v", opts)
+	}
+}
+
+// TestTailCount verifies the fallback used for one-shot requests.
+func TestTailCount(t *testing.T) {
+	cases := map[string]int{"10": 10, "1": 1, "all": defaultTail, "": defaultTail, "0": defaultTail, "-5": defaultTail}
+	for in, want := range cases {
+		if got := tailCount(in); got != want {
+			t.Errorf("tailCount(%q) = %d, want %d", in, got, want)
+		}
+	}
+}
+
+// TestDockerServiceLogsHandler_SinceInDays verifies end-to-end that a `since`
+// expressed in days reaches the Docker daemon as a timestamp instead of
+// failing the request and leaving the client without any logs.
+func TestDockerServiceLogsHandler_SinceInDays(t *testing.T) {
+	done := make(chan struct{})
+	sinceCh := make(chan string, 1)
+	dockerSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/services/") && strings.Contains(r.URL.Path, "/logs") {
+			select {
+			case sinceCh <- r.URL.Query().Get("since"):
+			default:
+			}
+			_, _ = w.Write([]byte("12345678hello\n"))
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+			<-done
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer dockerSrv.Close()
+	defer close(done)
+
+	defer ResetCli()
+	SetCli(makeClientForServer(t, dockerSrv.URL))
+
+	r := mux.NewRouter()
+	r.HandleFunc("/docker/logs/{id}", dockerServiceLogsHandler)
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	u, _ := url.Parse("ws" + strings.TrimPrefix(srv.URL, "http") + "/docker/logs/svc1")
+	q := u.Query()
+	q.Set("tail", "20")
+	q.Set("since", "2d")
+	q.Set("stdout", "true")
+	q.Set("stderr", "true")
+	q.Set("follow", "false")
+	q.Set("timestamps", "false")
+	q.Set("details", "false")
+	u.RawQuery = q.Encode()
+
+	conn, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, msg, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("expected a log line for since=2d, got error: %v", err)
+	}
+	if string(msg) != "hello" {
+		t.Fatalf("expected 'hello', got %q", string(msg))
+	}
+
+	select {
+	case since := <-sinceCh:
+		ts, convErr := strconv.ParseInt(since, 10, 64)
+		if convErr != nil {
+			t.Fatalf("expected a unix timestamp for since, got %q", since)
+		}
+		age := time.Since(time.Unix(ts, 0))
+		if age < 47*time.Hour || age > 49*time.Hour {
+			t.Fatalf("expected since to be ~48h ago, got %s", age)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("docker daemon was never called")
+	}
+}


### PR DESCRIPTION
Hi @heckenmann. 
In our internal fork of docker-swarm-dashboard, deployed across 12 Docker Swarm clusters with over 500 services per cluster, we have modified how logs are handled, and we would like to share these changes with you.
I hope this PR also addresses your issue #1076 too.

---
 
Fixes three user-visible bugs and refactors log streaming as described in #1076.

- **Typing in any filter input lost keyboard focus after one character.** `createHashAtomWithDefault` had an `async` read function, which always returns a new pending promise: every keystroke re-suspended the consumers and the `<Suspense fallback={null}>` around `ContentRouter` unmounted the whole view. The read is now synchronous once a value is in the URL hash. Measured in Chrome, typing `front`: before `value="f"`, focus on `BODY`, 3 history entries pushed — after, `value="front"`, focus kept, no history entry (hash writes now use `replaceState`).
- **The logs view dropped most of its output.** The backend sends one websocket message per log line, and reading them from `lastMessage` in an effect collapsed each burst into its final line — 8 of 20 lines lost in a browser measurement. Lines are now appended from the `onMessage` callback with a functional updater. The websocket close reason is also surfaced in the panel, so a failed request no longer looks like a service without logs.
- **`since` in days returned nothing.** The UI offers a `d` unit, but Go's `time.ParseDuration` does not understand days, so `ServiceLogs` failed and the socket closed empty. Days are normalized to hours server-side.
- **Opening logs for another service kept the previous one selected.** `handleShowLogsInternal` only closed the running session in follow mode, so without follow the previous service stayed on screen; and `ListGroup.Item action` renders a bare `<button>`, which defaults to `type="submit"` inside the setup form, so picking a service submitted it with the previously selected one.
- **Streaming refactor:** one context drives the request and is cancelled when the handler returns or the client disconnects; a single channel is owned and closed by the reader. This removes the `sync.Once`, the writer-done bookkeeping and the "channel full for 50 ms means slow client" logic, and fixes two goroutine leaks in the non-follow path. `writeLogPipeToClient` and `processPayload` are unchanged.
- **Verified:** `go vet`, `gofmt` and the full Go suite with `-race`; 875 frontend tests, eslint and prettier clean; all views smoke-tested in a real browser. Adds unit tests for the hash atoms, the logs component, the service selection and the `since` handling, plus a Cypress spec for the filter focus. Two existing tests asserted the old behaviour (`does not close logs when follow is not active`) and were updated.
- **Note:** a slow websocket client is no longer disconnected after 50 ms of backpressure but by the 10 s write deadline. Stripping Docker's 8-byte multiplex header is still done per line and stays heuristic (a 9-character line yields a size byte of `0x0A`, which shifts the parsing) — left for a separate change since fixing it means rewriting the existing fixtures.
