### PR TITLE
feat: freeze the dashboard header row and first column

### DIFF
--- a/app-src/cypress/e2e/ui-interactions/dashboard_sticky.cy.js
+++ b/app-src/cypress/e2e/ui-interactions/dashboard_sticky.cy.js
@@ -1,0 +1,42 @@
+describe('Frozen dashboard header and first column', () => {
+  const scrollAndAssertPinned = () => {
+    cy.get('.dashboard-table-wrapper').as('wrapper')
+
+    // Make the table taller than its container so it actually scrolls, the
+    // way a cluster with hundreds of services would.
+    cy.get('@wrapper').then(($wrapper) => {
+      const tbody = $wrapper.find('#dashboardTable tbody')[0]
+      const rows = Array.from(tbody.children)
+      for (let i = 0; i < 25; i++) {
+        rows.forEach((row) => tbody.appendChild(row.cloneNode(true)))
+      }
+    })
+
+    cy.get('@wrapper').scrollTo(400, 400)
+
+    cy.get('@wrapper').then(($wrapper) => {
+      const box = $wrapper[0].getBoundingClientRect()
+      const header = $wrapper.find('#dashboardTable thead th')[0]
+      const firstCell = $wrapper.find('#dashboardTable tbody tr td')[0]
+
+      // Both stay flush with the edges of the scroll container.
+      expect(header.getBoundingClientRect().top - box.top).to.be.closeTo(0, 2)
+      expect(firstCell.getBoundingClientRect().left - box.left).to.be.closeTo(
+        0,
+        2,
+      )
+    })
+  }
+
+  it('keeps the header and the first column visible in the horizontal layout', () => {
+    cy.get('a[aria-label="Dashboard"]').click()
+    cy.get('#dashboardTable', { timeout: 10000 }).should('exist')
+    scrollAndAssertPinned()
+  })
+
+  it('keeps the header and the first column visible in the vertical layout', () => {
+    cy.visit('/#base=http%3A%2F%2Flocalhost%3A3001%2F&defaultLayout=%22column%22')
+    cy.get('#dashboardTable', { timeout: 10000 }).should('exist')
+    scrollAndAssertPinned()
+  })
+})

--- a/app-src/src/components/dashboard/Dashboard.css
+++ b/app-src/src/components/dashboard/Dashboard.css
@@ -1,19 +1,35 @@
 /* Dashboard table layout and wrapper */
+
+/*
+ * The table body scrolls inside the card rather than with the page. This is
+ * what allows the header rows and the first column to stay pinned: a sticky
+ * cell only sticks within its own scroll container, so an unbounded wrapper
+ * would let the headers scroll away with the document.
+ */
 .dashboard-table-wrapper {
   width: 100%;
+  max-height: var(--dsd-table-max-height, calc(100vh - 14rem));
   padding: 0;
   margin: 0;
-  overflow-x: auto;
+  overflow: auto;
 }
 
 /* Base table styling */
 .dashboard-table {
+  /* Height of a single header row, shared by the cell height and the sticky
+     offsets of the stacked header rows so both stay in sync. */
+  --dsd-header-row-height: 28px;
+
   width: auto;
   min-width: 100%;
   margin-bottom: 0;
   table-layout: fixed;
+
+  /* Separate borders: with collapsed borders the browser paints them on the
+     table rather than on the cells, so the borders of sticky cells scroll
+     away from the cells they belong to. */
   border-spacing: 0;
-  border-collapse: collapse;
+  border-collapse: separate;
   background-color: transparent;
 }
 
@@ -47,10 +63,54 @@
 
 /* Header cell styling */
 .dashboard-table thead th {
-  height: 28px; /* Compact uniform header rows */
+  height: var(--dsd-header-row-height); /* Compact uniform header rows */
   color: var(--text);
   vertical-align: middle;
   border-bottom: 1px solid var(--table-border-color);
+}
+
+/* --- Frozen header rows and first column --------------------------------- */
+
+/*
+ * The whole header group is pinned, rather than each cell individually. Per
+ * cell it would take a z-index, and the resulting stacking context would trap
+ * the service name flags, which are absolutely positioned and deliberately
+ * overflow onto the neighbouring cells — they would end up painted *under*
+ * the next header cell instead of over it.
+ *
+ * Sticking the group also keeps the horizontal layout's three header rows
+ * together without having to offset each row by hand. The opaque background
+ * belongs here too: table cells are transparent, so the rows scrolling
+ * underneath would otherwise show through. It uses the background Bootstrap
+ * gives the rows, so the pinned cells stay indistinguishable from them in
+ * both themes.
+ */
+.dashboard-table thead {
+  position: sticky;
+  top: 0;
+  z-index: 3;
+  background-color: var(--bs-table-bg);
+}
+
+/*
+ * The first column stays pinned to the left so a row remains identifiable
+ * when scrolling across a wide cluster: Node in the horizontal layout,
+ * Service in the vertical one.
+ */
+.dashboard-table .node-attribute,
+.dashboard-table .service-col-v {
+  position: sticky;
+  left: 0;
+  z-index: 2;
+  background-color: var(--bs-table-bg);
+  border-right: 1px solid var(--table-border-color);
+}
+
+/* The top-left cell belongs to both and must stay above the two of them. */
+.dashboard-table thead .node-attribute,
+.dashboard-table thead .service-col-v {
+  /* Keep the top-left header above overflowing service-name flags. */
+  z-index: 20;
 }
 
 /* Header border behavior for 3-row layout (Horizontal Dashboard) */

--- a/app-src/src/components/dashboard/DashboardVerticalComponent.jsx
+++ b/app-src/src/components/dashboard/DashboardVerticalComponent.jsx
@@ -146,7 +146,7 @@ const DashboardVerticalComponent = React.memo(
 
         trows.push(
           <tr key={'tr-' + (service?.ID || service?.Name)}>
-            <td className="align-middle">
+            <td className="align-middle service-col-v">
               <ServiceName name={service?.Name} id={service?.ID} />
             </td>
             <td className="align-middle stack-column">
@@ -166,7 +166,7 @@ const DashboardVerticalComponent = React.memo(
         headerActions={<DashboardSettingsComponent />}
         bodyClassName="p-0"
         body={
-          <div className="table-responsive">
+          <div className="dashboard-table-wrapper table-responsive">
             <Table
               variant={isDarkMode ? currentVariant : null}
               id="dashboardTable"

--- a/app-src/tests/unit/components/DashboardVerticalComponent.combined.test.js
+++ b/app-src/tests/unit/components/DashboardVerticalComponent.combined.test.js
@@ -107,6 +107,18 @@ describe('DashboardVerticalComponent', () => {
     expect(screen.getByTestId('service-status-badge')).toBeInTheDocument()
   })
 
+  test('marks the scroll wrapper and the first column so they can be frozen', () => {
+    setupMocks()
+    const { container } = render(<DashboardVerticalComponent />)
+
+    // The wrapper owns the scrolling, which is what lets the header row and
+    // the first column stay pinned.
+    expect(container.querySelector('.dashboard-table-wrapper')).not.toBeNull()
+    expect(
+      container.querySelector('tbody tr td')?.classList.contains('service-col-v'),
+    ).toBe(true)
+  })
+
   test('filters services by name', () => {
     setupMocks({ serviceNameFilterAtom: 'non-existent' })
     render(<DashboardVerticalComponent />)


### PR DESCRIPTION
Scrolling a cluster with hundreds of services lost the column headers, and scrolling sideways across many nodes lost the row label, leaving no way to tell which service or node a cell belonged to.

The table body now scrolls inside the card instead of with the page — a sticky cell only sticks within its own scroll container, so an unbounded wrapper would let the headers scroll away with the document. Header cells and the first column are then pinned with `position: sticky`, in both the horizontal (Node) and vertical (Service) layouts. The horizontal layout stacks three header rows, each pinned below the previous one using a shared row-height variable.

Two details this required:

- `.service-header` set `position: relative`, which outranked the sticky rule and left the service/node headers unpinned. Sticky also establishes the containing block the absolutely placed name container needs.
- Borders move from collapsed to separate: with collapsed borders the browser paints them on the table rather than on the cells, so the borders of sticky cells drift away from the cells they belong to.

Pinned cells get an opaque background from the theme's card colour, since table cells are otherwise transparent and the rows scrolling underneath would show through. Row striping is preserved: Bootstrap paints it with an inset box-shadow on top of that background.