### PR TITLE
chore: configure Dependabot security update groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,12 @@ updates:
       - "automatic-merge"
     schedule:
       interval: "daily"
-      
+    groups:
+      security-updates:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+
   - package-ecosystem: "npm"
     directory: "/app-src"
     versioning-strategy: increase
@@ -30,6 +35,10 @@ updates:
         patterns:
           - "react"
           - "react-dom"
+      security-updates:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
 
   - package-ecosystem: "docker"
     directory: "/"


### PR DESCRIPTION
## Summary

Configure grouped Dependabot security updates for the npm and Go module ecosystems.

## Why

This makes security-update pull requests explicit and keeps resolvable vulnerable lockfile dependencies grouped by ecosystem for review.

## Impact

Dependabot will continue to create normal version-update pull requests as before. Security updates that have an available compatible upstream fix will be grouped into one PR per affected ecosystem. Alerts without a published upstream fix still require manual risk assessment.

## Validation

- Parsed `.github/dependabot.yml` with the project's `js-yaml` parser.
- Ran `git diff --check`.